### PR TITLE
Switch packet format to have destination length+name instead of op code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,15 @@
     <name>gg2-core-ipc</name>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.5.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -35,6 +41,16 @@
                 <version>1.4.2</version>
             </extension>
         </extensions>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
     </build>
     <distributionManagement>
         <snapshotRepository>

--- a/src/main/java/com/aws/iot/evergreen/ipc/IPCClientImpl.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/IPCClientImpl.java
@@ -35,13 +35,13 @@ public class IPCClientImpl implements IPCClient {
         this.reader = new ConnectionReader(clientSocket.getInputStream(), messageHandler);
         this.writer = new ConnectionWriter(clientSocket.getOutputStream());
         new Thread(reader).start();
-        sendRequest(new Message(AUTH_OP_CODE, config.getToken().getBytes()));
+        sendRequest(AUTH_SERVICE, new Message(config.getToken().getBytes()));
     }
 
     public boolean ping() {
-        Message msg = new Message(PING_OP_CODE, "ping".getBytes());
+        Message msg = new Message("ping".getBytes());
         try {
-            Message resp = sendRequest(msg).get();
+            Message resp = sendRequest(PING_SERVICE, msg).get();
             if (new String(resp.getPayload()).equals("pong")) {
                 return true;
             }
@@ -56,9 +56,9 @@ public class IPCClientImpl implements IPCClient {
         clientSocket.close();
     }
 
-    private CompletableFuture<Message> sendRequest(Message msg) {
+    private CompletableFuture<Message> sendRequest(String destination, Message msg) {
         //TODO: implement timeout for listening to requests
-        MessageFrame frame = new MessageFrame(msg, REQUEST);
+        MessageFrame frame = new MessageFrame(destination, msg, REQUEST);
         CompletableFuture<Message> future = new CompletableFuture<>();
         messageHandler.registerRequestId(frame.sequenceNumber, future);
         writer.write(frame);

--- a/src/main/java/com/aws/iot/evergreen/ipc/common/Constants.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/common/Constants.java
@@ -1,14 +1,7 @@
 package com.aws.iot.evergreen.ipc.common;
 
 public class Constants {
-
-    /**
-     IPC Service responds to a request with a message with opcode = ERROR_OP_CODE when
-        1. request had an invalid opcode
-        2. call back for an opcode returned an exception to IPC service
-     */
-    public final static int ERROR_OP_CODE = 1;
-    public final static int AUTH_OP_CODE = 2;
-    public final static int PING_OP_CODE = 60;
-
+    public final static String AUTH_SERVICE = "AUTH";
+    public final static String PING_SERVICE = "PING";
+    public final static String ERROR = "ERROR";
 }

--- a/src/test/java/com/aws/iot/evergreen/ipc/common/FrameReaderTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/common/FrameReaderTest.java
@@ -1,26 +1,24 @@
 package com.aws.iot.evergreen.ipc.common;
 
 import com.aws.iot.evergreen.ipc.common.FrameReader.Message;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
-import java.util.Arrays;
-import java.util.UUID;
 
 import static com.aws.iot.evergreen.ipc.common.FrameReader.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FrameReaderTest {
 
     @Test
     public void basicSanityCheck() throws Exception {
-        Message msg = new Message(255,  "Test Payload".getBytes());
-        MessageFrame inputFrame = new MessageFrame(1234,10,msg, FrameType.REQUEST);
+        Message msg = new Message( "Test Payload".getBytes());
+        MessageFrame inputFrame = new MessageFrame(1234,"10", msg, FrameType.REQUEST);
         MessageFrame outputFrame = serialiseAndRead(inputFrame);
         validate(inputFrame,outputFrame);
 
-        inputFrame = new MessageFrame(1234,10,msg, FrameType.RESPONSE);
+        inputFrame = new MessageFrame(1234,"10", msg, FrameType.RESPONSE);
         outputFrame = serialiseAndRead(inputFrame);
         validate(inputFrame,outputFrame);
     }
@@ -35,7 +33,7 @@ public class FrameReaderTest {
         assertEquals(inputFrame.sequenceNumber,outputFrame.sequenceNumber);
         assertEquals(inputFrame.type,outputFrame.type);
         assertEquals(inputFrame.version,outputFrame.version);
-        assertEquals(inputFrame.message.getOpCode(),outputFrame.message.getOpCode());
-        assertTrue(Arrays.equals(inputFrame.message.getPayload(),outputFrame.message.getPayload()));
+        assertEquals(inputFrame.destination,outputFrame.destination);
+        assertArrayEquals(inputFrame.message.getPayload(), outputFrame.message.getPayload());
     }
 }


### PR DESCRIPTION
Changes packet format to remove opcode which would be prone to overlapping problems. New format uses a "destination" name which is a UTF-8 string to disambiguate which service to deliver the IPC message to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.