### PR TITLE
Switch packet format to newly agreed protocol

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/ipc/IPCClient.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/IPCClient.java
@@ -20,15 +20,15 @@ public interface IPCClient {
      * @param msg         message to send
      * @return future containing the response (if any)
      */
-    CompletableFuture<FrameReader.Message> sendRequest(String destination, FrameReader.Message msg);
+    CompletableFuture<FrameReader.Message> sendRequest(int destination, FrameReader.Message msg);
 
     /**
      * Register a destination to receive incoming requests for a given destination.
      *
      * @param destination destination to register
-     * @param handler what to call when a message comes in
+     * @param handler     what to call when a message comes in
      */
-    void registerMessageHandler(String destination, Function<FrameReader.Message, FrameReader.Message> handler);
+    void registerMessageHandler(int destination, Function<FrameReader.Message, FrameReader.Message> handler);
 
     /**
      * Get this service's name.

--- a/src/main/java/com/aws/iot/evergreen/ipc/codec/MessageFrameDecoder.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/codec/MessageFrameDecoder.java
@@ -5,72 +5,20 @@
 package com.aws.iot.evergreen.ipc.codec;
 
 import com.aws.iot.evergreen.ipc.common.FrameReader;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ReplayingDecoder;
+import io.netty.handler.codec.ByteToMessageDecoder;
 
-import java.nio.charset.StandardCharsets;
+import java.io.DataInputStream;
 import java.util.List;
 
-public class MessageFrameDecoder extends ReplayingDecoder<Void> {
-    public static final int SEQ_NUM_AND_PAYLOAD_LENGTH_LENGTH = 6;
-    public static final int VERSION_AND_DEST_LENGTH_LENGTH = 2;
-    private static final int BYTE_MASK = 0xff;
-    private static final int IS_RESPONSE_MASK = 0x01;
-
-    /**
-     * Decode the input message.
-     * Message format is
-     *
-     * <P>+------------------+----------------------+---------------+---------------+------------------+------------+
-     *    | Version + Type   |  Destination Length  |  Destination  |  Seq. Number  |  Payload Length  |  Payload   |
-     *    |     1 byte       |         1 byte       |    x bytes    |    4 bytes    |      2 bytes     |  y bytes   |
-     *    +------------------+----------------------+---------------+---------------+------------------+------------+
-     *
-     */
+public class MessageFrameDecoder extends ByteToMessageDecoder {
     @Override
-    @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", justification = "markReaderIndex does have "
-            + "side effects, just findbugs doesn't know about it")
-    protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf, List<Object> list) {
-        byteBuf.markReaderIndex();
-
-        if (actualReadableBytes() < VERSION_AND_DEST_LENGTH_LENGTH) {
-            byteBuf.resetReaderIndex();
-            return;
+    protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf, List<Object> list)
+            throws Exception {
+        try (DataInputStream dataInputStream = new DataInputStream(new ByteBufInputStream(byteBuf))) {
+            list.add(FrameReader.readFrame(dataInputStream));
         }
-
-        final int firstByte = ((int) byteBuf.readByte()) & BYTE_MASK;
-        final int version = firstByte >> 1;
-        final FrameReader.FrameType type = FrameReader.FrameType.fromOrdinal(firstByte & IS_RESPONSE_MASK);
-
-        final int destinationNameLength = byteBuf.readByte();
-
-        if (actualReadableBytes() < destinationNameLength) {
-            byteBuf.resetReaderIndex();
-            return;
-        }
-
-        byte[] destinationNameByte = new byte[destinationNameLength];
-        byteBuf.readBytes(destinationNameByte);
-
-        if (actualReadableBytes() < SEQ_NUM_AND_PAYLOAD_LENGTH_LENGTH) {
-            byteBuf.resetReaderIndex();
-            return;
-        }
-
-        final int sequenceNumber = byteBuf.readInt();
-        final int payloadLength = byteBuf.readShort();
-
-        if (actualReadableBytes() < payloadLength) {
-            byteBuf.resetReaderIndex();
-            return;
-        }
-
-        byte[] payload = new byte[payloadLength];
-        byteBuf.readBytes(payload);
-
-        list.add(new FrameReader.MessageFrame(sequenceNumber, version,
-                new String(destinationNameByte, StandardCharsets.UTF_8), new FrameReader.Message(payload), type));
     }
 }

--- a/src/main/java/com/aws/iot/evergreen/ipc/codec/MessageFrameEncoder.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/codec/MessageFrameEncoder.java
@@ -13,6 +13,10 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import java.io.DataOutputStream;
 
 public class MessageFrameEncoder extends MessageToByteEncoder<FrameReader.MessageFrame> {
+    public static final int MAX_PAYLOAD_SIZE = (1 << 31) - 1;
+    public static final int LENGTH_FIELD_OFFSET = 6;
+    public static final int LENGTH_FIELD_LENGTH = 4;
+
     @Override
     protected void encode(ChannelHandlerContext channelHandlerContext, FrameReader.MessageFrame messageFrame,
                           ByteBuf byteBuf) throws Exception {

--- a/src/main/java/com/aws/iot/evergreen/ipc/common/BuiltInServiceDestinationCode.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/common/BuiltInServiceDestinationCode.java
@@ -1,0 +1,15 @@
+package com.aws.iot.evergreen.ipc.common;
+
+public enum BuiltInServiceDestinationCode {
+    AUTH(0), LIFECYCLE(1), SERVICE_DISCOVERY(2), ERROR(255);
+
+    private final int value;
+
+    BuiltInServiceDestinationCode(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/ipc/common/Constants.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/common/Constants.java
@@ -1,6 +1,0 @@
-package com.aws.iot.evergreen.ipc.common;
-
-public class Constants {
-    public static final String AUTH_SERVICE = "AUTH";
-    public static final String ERROR = "ERROR";
-}

--- a/src/main/java/com/aws/iot/evergreen/ipc/config/KernelIPCClientConfig.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/config/KernelIPCClientConfig.java
@@ -97,6 +97,7 @@ public class KernelIPCClientConfig {
 
         /**
          * Build config from builder.
+         *
          * @return built config
          */
         public KernelIPCClientConfig build() {

--- a/src/main/java/com/aws/iot/evergreen/ipc/services/common/IPCUtil.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/services/common/IPCUtil.java
@@ -22,14 +22,14 @@ public class IPCUtil {
     /**
      * Send a request to the server and then get the response as a future.
      *
-     * @param ipc IPC client used for sending the request
+     * @param ipc         IPC client used for sending the request
      * @param destination destination service to receive the request
-     * @param data the message to be sent
-     * @param clazz the type of the response which is expected
+     * @param data        the message to be sent
+     * @param clazz       the type of the response which is expected
      * @return future containing the deserialized response class
      */
     public static <T, E extends Enum<?> & GenericErrors> CompletableFuture<GeneralResponse<T, E>> sendAndReceive(
-            IPCClient ipc, String destination, Object data, TypeReference<GeneralResponse<T, E>> clazz) {
+            IPCClient ipc, int destination, Object data, TypeReference<GeneralResponse<T, E>> clazz) {
         byte[] payload;
         try {
             payload = encode(data);

--- a/src/main/java/com/aws/iot/evergreen/ipc/services/lifecycle/Lifecycle.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/services/lifecycle/Lifecycle.java
@@ -8,8 +8,6 @@ import java.util.function.BiConsumer;
  * Interface for Lifecycle operations.
  */
 public interface Lifecycle {
-    String LIFECYCLE_SERVICE_NAME = "LIFECYCLE";
-
     /**
      * Register a handler function to run upon the service moving to "shutdown" state.
      *

--- a/src/main/java/com/aws/iot/evergreen/ipc/services/servicediscovery/ServiceDiscovery.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/services/servicediscovery/ServiceDiscovery.java
@@ -8,8 +8,6 @@ import java.util.List;
  * Service Discovery client interface. Used to register and query resources registered by other services.
  */
 public interface ServiceDiscovery {
-    String SERVICE_DISCOVERY_NAME = "SERV_DISCO";
-
     /**
      * Register a resource. Previously registered resources cannot be updated: use updateResource instead.
      *

--- a/src/main/java/com/aws/iot/evergreen/ipc/services/servicediscovery/ServiceDiscoveryImpl.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/services/servicediscovery/ServiceDiscoveryImpl.java
@@ -1,6 +1,7 @@
 package com.aws.iot.evergreen.ipc.services.servicediscovery;
 
 import com.aws.iot.evergreen.ipc.IPCClient;
+import com.aws.iot.evergreen.ipc.common.BuiltInServiceDestinationCode;
 import com.aws.iot.evergreen.ipc.services.common.GeneralRequest;
 import com.aws.iot.evergreen.ipc.services.common.GeneralResponse;
 import com.aws.iot.evergreen.ipc.services.common.IPCUtil;
@@ -64,7 +65,8 @@ public class ServiceDiscoveryImpl implements ServiceDiscovery {
             throws ServiceDiscoveryException {
         try {
             GeneralResponse<T, ServiceDiscoveryResponseStatus> req =
-                    IPCUtil.sendAndReceive(ipc, SERVICE_DISCOVERY_NAME, data, clazz).get();
+                    IPCUtil.sendAndReceive(ipc, BuiltInServiceDestinationCode.SERVICE_DISCOVERY.getValue(), data, clazz)
+                            .get();
             if (!ServiceDiscoveryResponseStatus.Success.equals(req.getError())) {
                 throwOnError(req);
             }

--- a/src/test/java/com/aws/iot/evergreen/ipc/common/FrameReaderTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/common/FrameReaderTest.java
@@ -16,11 +16,11 @@ public class FrameReaderTest {
     @Test
     public void basicSanityCheck() {
         Message msg = new Message( "Test Payload".getBytes());
-        MessageFrame inputFrame = new MessageFrame(1234,"10", msg, FrameType.REQUEST);
+        MessageFrame inputFrame = new MessageFrame(1234,10, msg, FrameType.REQUEST);
         MessageFrame outputFrame = serialiseAndRead(inputFrame);
         validate(inputFrame,outputFrame);
 
-        inputFrame = new MessageFrame(1234,"10", msg, FrameType.RESPONSE);
+        inputFrame = new MessageFrame(1234,10, msg, FrameType.RESPONSE);
         outputFrame = serialiseAndRead(inputFrame);
         validate(inputFrame,outputFrame);
     }
@@ -34,7 +34,7 @@ public class FrameReaderTest {
     }
 
     private static void validate(MessageFrame inputFrame, MessageFrame outputFrame)  {
-        assertEquals(inputFrame.sequenceNumber,outputFrame.sequenceNumber);
+        assertEquals(inputFrame.requestId,outputFrame.requestId);
         assertEquals(inputFrame.type,outputFrame.type);
         assertEquals(inputFrame.version,outputFrame.version);
         assertEquals(inputFrame.destination,outputFrame.destination);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR switches the wire protocol to the newly agreed format which switches destination strings for integers. Also adds validation for version number range and destination number ranges before writing a message to the wire.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
