### PR TITLE
Additional log testing, ignore duplicated fields in EG Message

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/logging/impl/EvergreenStructuredLogMessage.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/EvergreenStructuredLogMessage.java
@@ -5,8 +5,11 @@
 package com.aws.iot.evergreen.logging.impl;
 
 import com.aws.iot.evergreen.logging.impl.plugins.layouts.StructuredLayout;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.Message;
 
@@ -20,22 +23,18 @@ import java.util.stream.Stream;
  * An implementation of {@link Message} interface to work with Evergreen {@link StructuredLayout}.
  */
 @Data
+@NoArgsConstructor
 public class EvergreenStructuredLogMessage implements Message {
     private static final long serialVersionUID = 0L;
 
-    final String level;
-
-    final String eventType;
-
-    final String message;
-
-    final Map<String, String> contexts;
-
-    final String loggerName;
-
-    final Long timestamp;
-
-    final Throwable cause;
+    private String level;
+    private String eventType;
+    private String message;
+    private Map<String, String> contexts;
+    private String loggerName;
+    private long timestamp;
+    @EqualsAndHashCode.Exclude
+    private Throwable cause;
 
     /**
      * Constructor for structured log {@link Message}.
@@ -59,6 +58,7 @@ public class EvergreenStructuredLogMessage implements Message {
         this.cause = cause;
     }
 
+    @JsonIgnore
     @Override
     public String getFormattedMessage() {
         return Stream.of(eventType, message, contexts)
@@ -68,11 +68,13 @@ public class EvergreenStructuredLogMessage implements Message {
                 .collect(Collectors.joining(". "));
     }
 
+    @JsonIgnore
     @Override
     public String getFormat() {
         return null;
     }
 
+    @JsonIgnore
     @SuppressFBWarnings(value = "PZLA_PREFER_ZERO_LENGTH_ARRAYS",
             justification = "change the serialization format by design and skip parameter values")
     @Override
@@ -80,6 +82,7 @@ public class EvergreenStructuredLogMessage implements Message {
         return null;
     }
 
+    @JsonIgnore
     @Override
     public Throwable getThrowable() {
         return this.cause;

--- a/src/main/java/com/aws/iot/evergreen/logging/impl/Log4jLogEventBuilder.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/Log4jLogEventBuilder.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * An implementation of {@link LogEventBuilder} providing a fluent API to generate log events.
@@ -20,7 +19,7 @@ public class Log4jLogEventBuilder implements LogEventBuilder {
     final Level level;
     Throwable cause;
     String eventType;
-    ConcurrentMap<String, String> eventContextData = new ConcurrentHashMap<>();
+    Map<String, String> eventContextData = new ConcurrentHashMap<>();
     Log4jLoggerAdapter logger;
 
     /**

--- a/src/main/java/com/aws/iot/evergreen/logging/impl/plugins/layouts/CBORLayout.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/plugins/layouts/CBORLayout.java
@@ -1,7 +1,7 @@
 package com.aws.iot.evergreen.logging.impl.plugins.layouts;
 
-import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
-import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 import org.apache.logging.log4j.core.LogEvent;
 
 import java.io.ByteArrayOutputStream;
@@ -13,7 +13,7 @@ class CBORLayout extends StructuredLayout {
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
     private static final int NUM_OF_BYTES_REPRESENTING_MESSAGE_LENGTH = 4;
     private static final byte[] ARRAY_REPRESENTING_MESSAGE_LENGTH = new byte[NUM_OF_BYTES_REPRESENTING_MESSAGE_LENGTH];
-    private final JSON encoder = JSON.std.with(new CBORFactory());
+    private static final ObjectMapper OBJECT_MAPPER = new CBORMapper();
 
     protected CBORLayout(Charset charset) {
         super(charset);
@@ -30,7 +30,7 @@ class CBORLayout extends StructuredLayout {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
             // appending 4 bytes for storing the length of the serialized log message
             byteArrayOutputStream.write(ARRAY_REPRESENTING_MESSAGE_LENGTH);
-            encoder.write(event.getMessage(), byteArrayOutputStream);
+            OBJECT_MAPPER.writeValue(byteArrayOutputStream, event.getMessage());
             byte[] eventInBytes = byteArrayOutputStream.toByteArray();
             // wrapping the bytes array in a buffer to write the size of the serialized payload
             // in the first four bytes

--- a/src/main/java/com/aws/iot/evergreen/logging/impl/plugins/layouts/JSONLayout.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/plugins/layouts/JSONLayout.java
@@ -1,6 +1,6 @@
 package com.aws.iot.evergreen.logging.impl.plugins.layouts;
 
-import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.core.LogEvent;
 
 import java.io.ByteArrayOutputStream;
@@ -9,7 +9,7 @@ import java.nio.charset.Charset;
 
 class JSONLayout extends StructuredLayout {
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
-    private final JSON encoder = JSON.std;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public JSONLayout(Charset charset) {
         super(charset);
@@ -24,7 +24,7 @@ class JSONLayout extends StructuredLayout {
     public byte[] toByteArray(LogEvent event) {
         try {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            encoder.write(event.getMessage(), byteArrayOutputStream);
+            OBJECT_MAPPER.writeValue(byteArrayOutputStream, event.getMessage());
             byteArrayOutputStream.write(System.lineSeparator().getBytes(charset));
             return byteArrayOutputStream.toByteArray();
         } catch (IOException e) {

--- a/src/test/java/com/aws/iot/evergreen/logging/impl/StructuredLayoutTest.java
+++ b/src/test/java/com/aws/iot/evergreen/logging/impl/StructuredLayoutTest.java
@@ -2,15 +2,13 @@ package com.aws.iot.evergreen.logging.impl;
 
 import com.aws.iot.evergreen.logging.impl.config.LogFormat;
 import com.aws.iot.evergreen.logging.impl.plugins.layouts.StructuredLayout;
-import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
 import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
-import com.fasterxml.jackson.jr.ob.JSON;
-import com.fasterxml.jackson.jr.stree.JacksonJrsTreeCodec;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.appender.OutputStreamAppender;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,9 +19,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class StructuredLayoutTest {
 
@@ -32,7 +32,6 @@ public class StructuredLayoutTest {
             StructuredLayout.createLayout(LogFormat.JSON, null, StandardCharsets.UTF_8);
     private static final StructuredLayout TEXT_LAYOUT =
             StructuredLayout.createLayout(LogFormat.TEXT, "%m%n", StandardCharsets.UTF_8);
-    private static final JSON CBOR_ENCODER = JSON.std.with(new JacksonJrsTreeCodec()).with(new CBORFactory());
     private static final ObjectMapper CBOR_MAPPER = new CBORMapper();
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     private static OutputStreamAppender cborOutputStreamAppender;
@@ -61,29 +60,45 @@ public class StructuredLayoutTest {
 
     @Test
     public void GIVEN_cbor_appender_WHEN_write_log_events_THEN_events_are_cbor_encoded() throws IOException {
-        List<SimpleMessage> messages = Arrays.asList(new SimpleMessage("message 1"), new SimpleMessage("message 2"),
-                new SimpleMessage("msg 3"));
+        List<Message> messages = Arrays.asList(
+                new EvergreenStructuredLogMessage("Logger", Level.INFO, "eventType", "message 1",
+                        new HashMap<String, String>() {{
+                            put("key", "value");
+                        }}, new Exception("EX!")),
+                new EvergreenStructuredLogMessage("Logger", Level.INFO, "eventType", "message 1", null, null),
+                new EvergreenStructuredLogMessage("Logger", Level.INFO, null, "message 1",
+                        new HashMap<String, String>() {{
+                            put("key", "value");
+                        }}, null));
         messages.forEach((m) -> {
             Log4jLogEvent log4jLogEvent = new Log4jLogEvent.Builder().setMessage(m).build();
             cborOutputStreamAppender.append(log4jLogEvent);
         });
 
         ByteBuffer buf = ByteBuffer.wrap(outContent.toByteArray());
-        for (SimpleMessage message : messages) {
+        for (Message message : messages) {
             int length = buf.getInt();
             byte[] arr = new byte[length];
             buf.get(arr);
-            TreeNode tree = CBOR_ENCODER.treeFrom(arr);
-            SimpleMessage deserializedMessage = tree.traverse(CBOR_MAPPER).readValueAs(SimpleMessage.class);
-            //comparing the original message with the de-serialized message
+            EvergreenStructuredLogMessage deserializedMessage =
+                    CBOR_MAPPER.readValue(arr, EvergreenStructuredLogMessage.class);
+            // comparing the original message with the de-serialized message
             assertEquals(message, deserializedMessage);
         }
     }
 
     @Test
-    public void GIVEN_json_appender_WHEN_write_log_events_THEN_events_are_json_encoded() throws IOException {
-        List<SimpleMessage> messages = Arrays.asList(new SimpleMessage("message 1"), new SimpleMessage("message 2"),
-                new SimpleMessage("msg 3"));
+    public void GIVEN_json_appender_WHEN_write_evergreen_log_events_THEN_events_are_json_encoded() throws IOException {
+        List<EvergreenStructuredLogMessage> messages = Arrays.asList(
+                new EvergreenStructuredLogMessage("Logger", Level.INFO, "eventType", "message 1",
+                        new HashMap<String, String>() {{
+                            put("key", "value");
+                        }}, new Exception("EX!")),
+                new EvergreenStructuredLogMessage("Logger", Level.INFO, "eventType", "message 1", null, null),
+                new EvergreenStructuredLogMessage("Logger", Level.INFO, null, "message 1",
+                        new HashMap<String, String>() {{
+                            put("key", "value");
+                        }}, null));
         messages.forEach((m) -> {
             Log4jLogEvent log4jLogEvent = new Log4jLogEvent.Builder().setMessage(m).build();
             jsonOutputStreamAppender.append(log4jLogEvent);
@@ -93,17 +108,32 @@ public class StructuredLayoutTest {
         String dataStr = new String(data, StandardCharsets.UTF_8);
         String[] appendedMessages = dataStr.split(System.lineSeparator());
         for (int i = 0; i < messages.size(); i++) {
-            SimpleMessage message = messages.get(i);
-            SimpleMessage deserializedMessage = JSON_MAPPER.readValue(appendedMessages[i], SimpleMessage.class);
+            EvergreenStructuredLogMessage message = messages.get(i);
+            EvergreenStructuredLogMessage deserializedMessage =
+                    JSON_MAPPER.readValue(appendedMessages[i], EvergreenStructuredLogMessage.class);
             //comparing the original message with the de-serialized message
             assertEquals(message, deserializedMessage);
+
+            // Separate compare the throwable because it doesn't deserialize to an exactly equal object
+            if (message.getCause() == null) {
+                assertNull(deserializedMessage.getCause());
+            } else {
+                assertEquals(message.getCause().getMessage(), deserializedMessage.getCause().getMessage());
+            }
         }
+        assertEquals(
+                "{\"level\":\"INFO\",\"eventType\":null,\"message\":\"message 1\",\"contexts\":{\"key\":\"value\"},"
+                        + "\"loggerName\":\"Logger\",\"timestamp\":" + messages.get(2).getTimestamp()
+                        + ",\"cause\":null}", appendedMessages[2]);
     }
 
     @Test
     public void GIVEN_text_appender_WHEN_write_log_events_THEN_events_are_patterned_as_text() throws IOException {
-        List<SimpleMessage> messages = Arrays.asList(new SimpleMessage("message 1"), new SimpleMessage("message 2"),
-                new SimpleMessage("msg 3"));
+        List<Message> messages = Arrays.asList(new SimpleMessage("message 1"), new SimpleMessage("message 2"),
+                new SimpleMessage("msg 3"), new EvergreenStructuredLogMessage("Logger", Level.INFO, null, "message 1",
+                        new HashMap<String, String>() {{
+                            put("key", "value");
+                        }}, null));
         messages.forEach((m) -> {
             Log4jLogEvent log4jLogEvent = new Log4jLogEvent.Builder().setMessage(m).build();
             textOutputStreamAppender.append(log4jLogEvent);
@@ -113,7 +143,7 @@ public class StructuredLayoutTest {
         String dataStr = new String(data, StandardCharsets.UTF_8);
         String[] appendedMessages = dataStr.split(System.lineSeparator());
         for (int i = 0; i < messages.size(); i++) {
-            SimpleMessage message = messages.get(i);
+            Message message = messages.get(i);
             assertEquals(message.getFormattedMessage(), appendedMessages[i]);
         }
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds `@JsonIgnore` to getters in `EvergreenStructuredLogMessage` so that fields are not multiply serialized. Add new test to check that `EvergreenStructuredLogMessage` is properly serialized and deserializable.

**Why is this change necessary:**
Add more testing which found issues in how the EG message was serialized.

**How was this change tested:**
Added new test.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
