### PR TITLE
Add supplier for default key-value in logger

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/logging/api/Logger.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/api/Logger.java
@@ -5,6 +5,8 @@
 
 package com.aws.iot.evergreen.logging.api;
 
+import java.util.function.Supplier;
+
 /**
  * Evergreen Logger interface.
  */
@@ -33,6 +35,15 @@ public interface Logger {
      * @return the logger instance
      */
     Logger dfltKv(String key, Object value);
+
+    /**
+     * Add a key-value pair of common contextual information related to the logger.
+     *
+     * @param key   a unique key
+     * @param value supplier for the value
+     * @return the logger instance
+     */
+    Logger dfltKv(String key, Supplier<Object> value);
 
     /**
      * Entry point for fluent logging in TRACE level.

--- a/src/main/java/com/aws/iot/evergreen/logging/impl/Log4jLogEventBuilder.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/Log4jLogEventBuilder.java
@@ -26,6 +26,7 @@ public class Log4jLogEventBuilder implements LogEventBuilder {
     private Throwable cause;
     private String eventType;
     private final Map<String, Object> eventContextData = new ConcurrentHashMap<>();
+    private final Map<String, Supplier<Object>> eventContextDataSupplier = new ConcurrentHashMap<>();
     private transient Log4jLoggerAdapter logger;
     private static final CopyOnWriteArraySet<Consumer<EvergreenStructuredLogMessage>> listeners
             = new CopyOnWriteArraySet<>();
@@ -36,10 +37,13 @@ public class Log4jLogEventBuilder implements LogEventBuilder {
      * @param level the log level setting on the logger
      * @param loggerContextData a map of key value pairs with contextual information for the logger
      */
-    public Log4jLogEventBuilder(Log4jLoggerAdapter logger, Level level, Map<String, Object> loggerContextData) {
+    public Log4jLogEventBuilder(Log4jLoggerAdapter logger, Level level,
+                                Map<String, Object> loggerContextData,
+                                Map<String, Supplier<Object>> loggerContextDataSupplier) {
         this.logger = logger;
         this.level = level;
         eventContextData.putAll(loggerContextData);
+        eventContextDataSupplier.putAll(loggerContextDataSupplier);
     }
 
     @Override
@@ -85,6 +89,7 @@ public class Log4jLogEventBuilder implements LogEventBuilder {
         // Convert context to string, then log it out
         Map<String, String> contextMap = new HashMap<>();
         eventContextData.forEach((k, v) -> contextMap.put(k, convertToString(v)));
+        eventContextDataSupplier.forEach((k, v) -> contextMap.put(k, convertToString(v.get())));
 
         EvergreenStructuredLogMessage message = new EvergreenStructuredLogMessage(logger
                 .getName(), level, eventType, arg.toString(), contextMap, cause);


### PR DESCRIPTION
**Issue #, if available:**
in Evergreen Kernel, we have logger built like this:
```
logger.dfltKv(CURRENT_STATE_METRIC_NAME, (Supplier<State>) this::getState);
```

This cause the log line output looks like
```
... {currentState=<lambda function address>}
```

Which isn't what we intend.


**Description of changes:**


**Why is this change necessary:**

**How was this change tested:**
tested to verify "currentState" is correctly logged

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
