### PR TITLE
Run ConfigStore callbacks in separate Executor

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Convert Jacoco to Cobertura
         run: curl -o cover2cover.py https://gist.githubusercontent.com/MikeDombo/82567fccc1b2aced0c76fc053efd5a26/raw/f79f748f37cabb4cedd186321ea70e9fb383815d/cover2cover.py && python3 cover2cover.py target/jacoco-report/jacoco.xml src/main/java > target/jacoco-report/cobertura.xml
       - name: cobertura-report
-        uses: 5monkeys/cobertura-action@v2
+        uses: 5monkeys/cobertura-action@master
         with:
           # The GITHUB_TOKEN for this repo
           repo_token: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.iot</groupId>
     <artifactId>evergreen-java-sdk</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -159,6 +159,7 @@
                     <threshold>Low</threshold>
                     <xmlOutput>true</xmlOutput>
                     <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+                    <skip>${skipTests}</skip>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/com/aws/iot/evergreen/ipc/IPCClientImpl.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/IPCClientImpl.java
@@ -32,7 +32,8 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -40,7 +41,6 @@ import java.util.function.Function;
 import static com.aws.iot.evergreen.ipc.codec.MessageFrameEncoder.LENGTH_FIELD_LENGTH;
 import static com.aws.iot.evergreen.ipc.codec.MessageFrameEncoder.LENGTH_FIELD_OFFSET;
 import static com.aws.iot.evergreen.ipc.codec.MessageFrameEncoder.MAX_PAYLOAD_SIZE;
-import static com.aws.iot.evergreen.ipc.common.BuiltInServiceDestinationCode.AUTH;
 import static com.aws.iot.evergreen.ipc.common.FrameReader.FrameType.REQUEST;
 import static com.aws.iot.evergreen.ipc.common.FrameReader.FrameType.RESPONSE;
 import static com.aws.iot.evergreen.ipc.common.FrameReader.Message;
@@ -51,6 +51,7 @@ import static com.aws.iot.evergreen.ipc.common.FrameReader.MessageFrame;
 //TODO: throw ipc client specific runtime exceptions
 public class IPCClientImpl implements IPCClient {
 
+    public static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
     private final MessageHandler messageHandler;
     private final EventLoopGroup eventLoopGroup;
     private final Bootstrap clientBootstrap;

--- a/src/main/java/com/aws/iot/evergreen/ipc/services/configstore/ConfigStoreImpl.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/services/configstore/ConfigStoreImpl.java
@@ -6,6 +6,7 @@
 package com.aws.iot.evergreen.ipc.services.configstore;
 
 import com.aws.iot.evergreen.ipc.IPCClient;
+import com.aws.iot.evergreen.ipc.IPCClientImpl;
 import com.aws.iot.evergreen.ipc.common.FrameReader;
 import com.aws.iot.evergreen.ipc.services.common.ApplicationMessage;
 import com.aws.iot.evergreen.ipc.services.common.IPCUtil;
@@ -65,7 +66,7 @@ public class ConfigStoreImpl implements ConfigStore {
                 ConfigKeyChangedEvent changedEvent =
                         IPCUtil.decode(request.getPayload(), ConfigKeyChangedEvent.class);
 
-                callbacks.forEach(f -> f.accept(changedEvent.getChangedKey()));
+                IPCClientImpl.EXECUTOR.execute(() -> callbacks.forEach(f -> f.accept(changedEvent.getChangedKey())));
             } else {
                 resp = ConfigStoreResponseStatus.InvalidRequest;
             }

--- a/src/main/java/com/aws/iot/evergreen/ipc/services/configstore/ConfigStoreReadValueResponse.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/services/configstore/ConfigStoreReadValueResponse.java
@@ -10,11 +10,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class ConfigStoreReadValueResponse extends ConfigStoreGenericResponse {
     private Object value;
 

--- a/src/main/java/com/aws/iot/evergreen/ipc/services/servicediscovery/LookupResourceResponse.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/services/servicediscovery/LookupResourceResponse.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class LookupResourceResponse extends ServiceDiscoveryGenericResponse {
 
     private List<Resource> resources;

--- a/src/main/java/com/aws/iot/evergreen/ipc/services/servicediscovery/RegisterResourceResponse.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/services/servicediscovery/RegisterResourceResponse.java
@@ -10,11 +10,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class RegisterResourceResponse extends ServiceDiscoveryGenericResponse {
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This is a temporary fix to make calling IPC commands like `ConfigStore.read()` in the callback from `ConfigStore.subscribe()` work. This is currently broken because the Netty thread is blocked and cannot process incoming requests until the current (subscription notification) request has been completed. 

This is not a very nice fix and will be going away when the IoT SDK replaces us.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
