### PR TITLE
Prevent Log4J automatically shutting down in shutdown hook

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/logging/impl/plugins/Log4jConfigurationFactory.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/plugins/Log4jConfigurationFactory.java
@@ -39,7 +39,9 @@ public class Log4jConfigurationFactory extends ConfigurationFactory {
         String logAppenderName = name.concat(logConfig.CONFIG_PREFIX);
         configureLoggerAppender(logConfig, logAppenderName, builder);
         builder.add(builder.newRootLogger(logConfig.getLevel()).add(builder.newAppenderRef(logAppenderName)));
-        builder.setShutdownHook("disable"); // Disable Log4J shutdown hook
+        // Disable Log4J shutdown hook because otherwise it can shutdown while the kernel is also shutting down
+        // thus preventing us from logging during the kernel shutdown.
+        builder.setShutdownHook("disable");
 
         // Configure metrics logger
         EvergreenMetricsConfig metricsConfig = new EvergreenMetricsConfig();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Log4J automatically shutsdown and stops logging anything in a shutdown hook. Java runs the hooks in parallel, so we don't have a way of continuing to log while the kernel performs the shutdown. This change disables the shutdown hook so that we can continue to log to log4j.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
