### PR TITLE
Implement our logger with Slf4j binding so that other libraries that use slf4j will use our logger

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/logging/impl/LogManager.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/LogManager.java
@@ -9,7 +9,6 @@ import com.aws.iot.evergreen.logging.api.MetricsFactory;
 import com.aws.iot.evergreen.logging.impl.config.EvergreenLogConfig;
 import lombok.Getter;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -21,13 +20,10 @@ import java.util.concurrent.ConcurrentMap;
 public class LogManager {
 
     // key: name (String), value: a Logger;
-    private static ConcurrentMap<String, com.aws.iot.evergreen.logging.api.Logger> loggerMap =
+    private static final ConcurrentMap<String, com.aws.iot.evergreen.logging.api.Logger> loggerMap =
             new ConcurrentHashMap<>();
     @Getter
     private static final EvergreenLogConfig config = EvergreenLogConfig.getInstance();
-
-    protected LogManager() {
-    }
 
     /**
      * Return an appropriate {@link com.aws.iot.evergreen.logging.api.Logger} instance as specified by the name
@@ -38,7 +34,7 @@ public class LogManager {
      */
     public static com.aws.iot.evergreen.logging.api.Logger getLogger(String name) {
         return loggerMap.computeIfAbsent(name, n -> {
-            Logger logger = LoggerFactory.getLogger(name);
+            Logger logger = config.getLogger(name);
             return new Slf4jLogAdapter(logger, config);
         });
     }

--- a/src/main/java/com/aws/iot/evergreen/logging/impl/Slf4jFactory.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/Slf4jFactory.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.iot.evergreen.logging.impl;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+public class Slf4jFactory implements ILoggerFactory {
+    public Slf4jFactory() {
+    }
+
+    @Override
+    public Logger getLogger(String name) {
+        return wrapLogger(LogManager.getLogger(name));
+    }
+
+    private Logger wrapLogger(com.aws.iot.evergreen.logging.api.Logger logger) {
+        return new LogAdapter(logger);
+    }
+
+    /**
+     * Adapts Slf4j interface to our logger.
+     */
+    private static class LogAdapter implements Logger {
+        private final com.aws.iot.evergreen.logging.api.Logger logger;
+
+        public LogAdapter(com.aws.iot.evergreen.logging.api.Logger logger) {
+            this.logger = logger;
+        }
+
+        @Override
+        public String getName() {
+            return logger.getName();
+        }
+
+        @Override
+        public boolean isTraceEnabled() {
+            return logger.isTraceEnabled();
+        }
+
+        @Override
+        public boolean isTraceEnabled(Marker marker) {
+            return logger.isTraceEnabled();
+        }
+
+        @Override
+        public void trace(String msg) {
+            logger.trace(msg);
+        }
+
+        @Override
+        public void trace(String format, Object arg) {
+            logger.trace(format, arg);
+        }
+
+        @Override
+        public void trace(String format, Object argA, Object argB) {
+            logger.trace(format, argA, argB);
+        }
+
+        @Override
+        public void trace(String format, Object... arguments) {
+            logger.trace(format, arguments);
+        }
+
+        @Override
+        public void trace(String msg, Throwable t) {
+            logger.trace(msg, t);
+        }
+
+        @Override
+        public void trace(Marker marker, String msg) {
+            logger.trace(msg);
+        }
+
+        @Override
+        public void trace(Marker marker, String format, Object arg) {
+            logger.trace(format, arg);
+        }
+
+        @Override
+        public void trace(Marker marker, String format, Object arg1, Object arg2) {
+            logger.trace(format, arg1, arg2);
+        }
+
+        @Override
+        public void trace(Marker marker, String format, Object... argArray) {
+            logger.trace(format, argArray);
+        }
+
+        @Override
+        public void trace(Marker marker, String msg, Throwable t) {
+            logger.trace(msg, t);
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return logger.isDebugEnabled();
+        }
+
+        @Override
+        public boolean isDebugEnabled(Marker marker) {
+            return logger.isDebugEnabled();
+        }
+
+        @Override
+        public void debug(String msg) {
+            logger.debug(msg);
+        }
+
+        @Override
+        public void debug(String format, Object arg) {
+            logger.debug(format, arg);
+        }
+
+        @Override
+        public void debug(String format, Object argA, Object argB) {
+            logger.debug(format, argA, argB);
+        }
+
+        @Override
+        public void debug(String format, Object... arguments) {
+            logger.debug(format, arguments);
+        }
+
+        @Override
+        public void debug(String msg, Throwable t) {
+            logger.debug(msg, t);
+        }
+
+        @Override
+        public void debug(Marker marker, String msg) {
+            logger.debug(msg);
+        }
+
+        @Override
+        public void debug(Marker marker, String format, Object arg) {
+            logger.debug(format, arg);
+        }
+
+        @Override
+        public void debug(Marker marker, String format, Object arg1, Object arg2) {
+            logger.debug(format, arg1, arg2);
+        }
+
+        @Override
+        public void debug(Marker marker, String format, Object... arguments) {
+            logger.debug(format, arguments);
+        }
+
+        @Override
+        public void debug(Marker marker, String msg, Throwable t) {
+            logger.debug(msg, t);
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return logger.isInfoEnabled();
+        }
+
+        @Override
+        public boolean isInfoEnabled(Marker marker) {
+            return logger.isInfoEnabled();
+        }
+
+        @Override
+        public void info(String msg) {
+            logger.info(msg);
+        }
+
+        @Override
+        public void info(String format, Object arg) {
+            logger.info(format, arg);
+        }
+
+        @Override
+        public void info(String format, Object argA, Object argB) {
+            logger.info(format, argA, argB);
+        }
+
+        @Override
+        public void info(String format, Object... arguments) {
+            logger.info(format, arguments);
+        }
+
+        @Override
+        public void info(String msg, Throwable t) {
+            logger.info(msg, t);
+        }
+
+        @Override
+        public void info(Marker marker, String msg) {
+            logger.info(msg);
+        }
+
+        @Override
+        public void info(Marker marker, String format, Object arg) {
+            logger.info(format, arg);
+        }
+
+        @Override
+        public void info(Marker marker, String format, Object arg1, Object arg2) {
+            logger.info(format, arg1, arg2);
+        }
+
+        @Override
+        public void info(Marker marker, String format, Object... arguments) {
+            logger.info(format, arguments);
+        }
+
+        @Override
+        public void info(Marker marker, String msg, Throwable t) {
+            logger.info(msg, t);
+        }
+
+        @Override
+        public boolean isWarnEnabled() {
+            return logger.isWarnEnabled();
+        }
+
+        @Override
+        public boolean isWarnEnabled(Marker marker) {
+            return logger.isWarnEnabled();
+        }
+
+        @Override
+        public void warn(String msg) {
+            logger.warn(msg);
+        }
+
+        @Override
+        public void warn(String format, Object arg) {
+            logger.warn(format, arg);
+        }
+
+        @Override
+        public void warn(String format, Object argA, Object argB) {
+            logger.warn(format, argA, argB);
+        }
+
+        @Override
+        public void warn(String format, Object... arguments) {
+            logger.warn(format, arguments);
+        }
+
+        @Override
+        public void warn(String msg, Throwable t) {
+            logger.warn(msg, t);
+        }
+
+        @Override
+        public void warn(Marker marker, String msg) {
+            logger.warn(msg);
+        }
+
+        @Override
+        public void warn(Marker marker, String format, Object arg) {
+            logger.warn(format, arg);
+        }
+
+        @Override
+        public void warn(Marker marker, String format, Object arg1, Object arg2) {
+            logger.warn(format, arg1, arg2);
+        }
+
+        @Override
+        public void warn(Marker marker, String format, Object... arguments) {
+            logger.warn(format, arguments);
+        }
+
+        @Override
+        public void warn(Marker marker, String msg, Throwable t) {
+            logger.warn(msg, t);
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return logger.isErrorEnabled();
+        }
+
+        @Override
+        public boolean isErrorEnabled(Marker marker) {
+            return logger.isErrorEnabled();
+        }
+
+        @Override
+        public void error(String msg) {
+            logger.error(msg);
+        }
+
+        @Override
+        public void error(String format, Object arg) {
+            logger.error(format, arg);
+        }
+
+        @Override
+        public void error(String format, Object argA, Object argB) {
+            logger.error(format, argA, argB);
+        }
+
+        @Override
+        public void error(String format, Object... arguments) {
+            logger.error(format, arguments);
+        }
+
+        @Override
+        public void error(String msg, Throwable t) {
+            logger.error(msg, t);
+        }
+
+        @Override
+        public void error(Marker marker, String msg) {
+            logger.error(msg);
+        }
+
+        @Override
+        public void error(Marker marker, String format, Object arg) {
+            logger.error(format, arg);
+        }
+
+        @Override
+        public void error(Marker marker, String format, Object arg1, Object arg2) {
+            logger.error(format, arg1, arg2);
+        }
+
+        @Override
+        public void error(Marker marker, String format, Object... arguments) {
+            logger.error(format, arguments);
+        }
+
+        @Override
+        public void error(Marker marker, String msg, Throwable t) {
+            logger.error(msg, t);
+        }
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/logging/impl/config/EvergreenLogConfig.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/config/EvergreenLogConfig.java
@@ -6,14 +6,9 @@
 package com.aws.iot.evergreen.logging.impl.config;
 
 import ch.qos.logback.classic.Logger;
-import com.aws.iot.evergreen.logging.impl.LogManager;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.netty.util.internal.logging.AbstractInternalLogger;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
+import ch.qos.logback.classic.LoggerContext;
 import lombok.Getter;
 import lombok.Setter;
-import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 @Getter
@@ -22,6 +17,7 @@ public class EvergreenLogConfig extends PersistenceConfig {
     public static final String LOG_LEVEL_KEY = "log.level";
     private static final String DEFAULT_LOG_LEVEL = "INFO";
     public static final String CONFIG_PREFIX = "log";
+    private static final LoggerContext context = new LoggerContext();
 
     @Setter
     private Level level;
@@ -39,182 +35,10 @@ public class EvergreenLogConfig extends PersistenceConfig {
         super(CONFIG_PREFIX);
 
         this.level = Level.valueOf(System.getProperty(LOG_LEVEL_KEY, DEFAULT_LOG_LEVEL));
-        reconfigure((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME));
-
-        configureNettyLogging();
+        reconfigure(context.getLogger(Logger.ROOT_LOGGER_NAME));
     }
 
-    // Interface with Netty's internal logger so that it uses our logger
-    private void configureNettyLogging() {
-        InternalLoggerFactory.setDefaultFactory(new NettyLoggerFactory());
-    }
-
-    private static class NettyLoggerFactory extends InternalLoggerFactory {
-        @Override
-        protected InternalLogger newInstance(String name) {
-            com.aws.iot.evergreen.logging.api.Logger logger = LogManager.getLogger(name);
-            return new NettyLogAdapter(name, logger);
-        }
-
-        @SuppressFBWarnings("SE_BAD_FIELD")
-        private static class NettyLogAdapter extends AbstractInternalLogger {
-            private static final long serialVersionUID = -6382972526573193470L;
-            private final com.aws.iot.evergreen.logging.api.Logger logger;
-
-            public NettyLogAdapter(String name, com.aws.iot.evergreen.logging.api.Logger logger) {
-                super(name);
-                this.logger = logger;
-            }
-
-            @Override
-            public boolean isTraceEnabled() {
-                return logger.isTraceEnabled();
-            }
-
-            @Override
-            public void trace(String msg) {
-                logger.trace(msg);
-            }
-
-            @Override
-            public void trace(String format, Object arg) {
-                logger.trace(format, arg);
-            }
-
-            @Override
-            public void trace(String format, Object argA, Object argB) {
-                logger.trace(format, argA, argB);
-            }
-
-            @Override
-            public void trace(String format, Object... arguments) {
-                logger.trace(format, arguments);
-            }
-
-            @Override
-            public void trace(String msg, Throwable t) {
-                logger.trace(msg, t);
-            }
-
-            @Override
-            public boolean isDebugEnabled() {
-                return logger.isDebugEnabled();
-            }
-
-            @Override
-            public void debug(String msg) {
-                logger.debug(msg);
-            }
-
-            @Override
-            public void debug(String format, Object arg) {
-                logger.debug(format, arg);
-            }
-
-            @Override
-            public void debug(String format, Object argA, Object argB) {
-                logger.debug(format, argA, argB);
-            }
-
-            @Override
-            public void debug(String format, Object... arguments) {
-                logger.debug(format, arguments);
-            }
-
-            @Override
-            public void debug(String msg, Throwable t) {
-                logger.debug(msg, t);
-            }
-
-            @Override
-            public boolean isInfoEnabled() {
-                return logger.isInfoEnabled();
-            }
-
-            @Override
-            public void info(String msg) {
-                logger.info(msg);
-            }
-
-            @Override
-            public void info(String format, Object arg) {
-                logger.info(format, arg);
-            }
-
-            @Override
-            public void info(String format, Object argA, Object argB) {
-                logger.info(format, argA, argB);
-            }
-
-            @Override
-            public void info(String format, Object... arguments) {
-                logger.info(format, arguments);
-            }
-
-            @Override
-            public void info(String msg, Throwable t) {
-                logger.info(msg, t);
-            }
-
-            @Override
-            public boolean isWarnEnabled() {
-                return logger.isWarnEnabled();
-            }
-
-            @Override
-            public void warn(String msg) {
-                logger.warn(msg);
-            }
-
-            @Override
-            public void warn(String format, Object arg) {
-                logger.warn(format, arg);
-            }
-
-            @Override
-            public void warn(String format, Object argA, Object argB) {
-                logger.warn(format, argA, argB);
-            }
-
-            @Override
-            public void warn(String format, Object... arguments) {
-                logger.warn(format, arguments);
-            }
-
-            @Override
-            public void warn(String msg, Throwable t) {
-                logger.warn(msg, t);
-            }
-
-            @Override
-            public boolean isErrorEnabled() {
-                return logger.isErrorEnabled();
-            }
-
-            @Override
-            public void error(String msg) {
-                logger.error(msg);
-            }
-
-            @Override
-            public void error(String format, Object arg) {
-                logger.error(format, arg);
-            }
-
-            @Override
-            public void error(String format, Object argA, Object argB) {
-                logger.error(format, argA, argB);
-            }
-
-            @Override
-            public void error(String format, Object... arguments) {
-                logger.error(format, arguments);
-            }
-
-            @Override
-            public void error(String msg, Throwable t) {
-                logger.error(msg, t);
-            }
-        }
+    public Logger getLogger(String name) {
+        return context.getLogger(name);
     }
 }

--- a/src/main/java/com/aws/iot/evergreen/logging/impl/config/EvergreenMetricsConfig.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/config/EvergreenMetricsConfig.java
@@ -7,7 +7,6 @@ package com.aws.iot.evergreen.logging.impl.config;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.slf4j.LoggerFactory;
 
 import static com.aws.iot.evergreen.logging.impl.MetricsFactoryImpl.METRIC_LOGGER_NAME;
 
@@ -37,7 +36,7 @@ public class EvergreenMetricsConfig extends PersistenceConfig {
             enabled = Boolean.parseBoolean(enabledStr);
         }
         this.enabled = enabled;
-        reconfigure((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(METRIC_LOGGER_NAME));
+        reconfigure(EvergreenLogConfig.getInstance().getLogger(METRIC_LOGGER_NAME));
     }
 
     public static EvergreenMetricsConfig getInstance() {

--- a/src/main/java/com/aws/iot/evergreen/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/config/PersistenceConfig.java
@@ -14,7 +14,6 @@ import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
 import ch.qos.logback.core.util.FileSize;
 import lombok.Getter;
-import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -103,7 +102,7 @@ public class PersistenceConfig {
     }
 
     protected void reconfigure(Logger loggerToConfigure) {
-        LoggerContext logCtx = (LoggerContext) LoggerFactory.getILoggerFactory();
+        LoggerContext logCtx = loggerToConfigure.getLoggerContext();
 
         BasicEncoder basicEncoder = new BasicEncoder();
         basicEncoder.setContext(logCtx);

--- a/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.slf4j.impl;
+
+import com.aws.iot.evergreen.logging.impl.Slf4jFactory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+import org.slf4j.spi.LoggerFactoryBinder;
+
+/**
+ * The binding of {@link LoggerFactory} class with an actual instance of {@link ILoggerFactory} is performed using
+ * information returned by this class.
+ *
+ * <p>Modified from Logback's implementation
+ */
+@SuppressFBWarnings({"MS_SHOULD_BE_FINAL", "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
+public class StaticLoggerBinder implements LoggerFactoryBinder {
+    private static final StaticLoggerBinder INSTANCE = new StaticLoggerBinder();
+    private static final Slf4jFactory factory = new Slf4jFactory();
+    // to avoid constant folding by the compiler, this field must *not* be final
+    public static String REQUESTED_API_VERSION = "1.7.16"; // !final
+
+    private StaticLoggerBinder() {
+    }
+
+    public static StaticLoggerBinder getSingleton() {
+        return INSTANCE;
+    }
+
+    public ILoggerFactory getLoggerFactory() {
+        return factory;
+    }
+
+    public String getLoggerFactoryClassStr() {
+        return factory.getClass().getName();
+    }
+
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Libraries like Netty and AWS SDK bind to Slf4j which will go to our backend logger (logback). This change makes us implement slf4j logging so that it binds to us and we can control the log level, etc.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
