### PR TITLE
Allow changing log level per-logger

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/logging/api/Logger.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/api/Logger.java
@@ -259,6 +259,10 @@ public interface Logger {
      */
     void error(String message, Object... args);
 
-    // TODO: Add configuration interface and dynamic reload https://sim.amazon.com/issues/P31935972
-    // void reloadConfig(topics config);
+    /**
+     * Change the logger's level.
+     *
+     * @param level new level value
+     */
+    void setLevel(String level);
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Allows changing the log level unique to each logger. If set, it completely overrides the global log level setting until it is reset to `null`.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
