### PR TITLE
Add createChild() method to logger to create child logger which inherits from parent

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/logging/api/Logger.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/api/Logger.java
@@ -265,4 +265,10 @@ public interface Logger {
      * @param level new level value
      */
     void setLevel(String level);
+
+    /**
+     * Copy this logger to a new logger and inherit the default context.
+     * New logger keeps the old logger's name and will follow the old logger's level.
+     */
+    Logger createChild();
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds new method `createChild()` to our `Logger`. This is used to create new instances of a logger which has the same name and log level, and will inherit any key-value pairs from the parent.

The use case for this is to be able to pass around a logger which has a default context already set up, and then be able to use it multiple times. Currently we could pass around a log builder, but that could only be used one time.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
