### PR TITLE
Initial AuthorizationClient implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <distributionManagement>

--- a/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationClient.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationClient.java
@@ -1,0 +1,52 @@
+package com.aws.iot.evergreen.ipc.authorization;
+
+import com.aws.iot.evergreen.ipc.IPCClient;
+import com.aws.iot.evergreen.ipc.services.common.IPCUtil;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static com.aws.iot.evergreen.ipc.common.BuiltInServiceDestinationCode.AUTHORIZATION;
+
+public class AuthorizationClient {
+
+    public static final int AUTHORIZATION_API_VERSION = 1;
+    private final IPCClient ipc;
+
+    public AuthorizationClient(IPCClient ipc) {
+        this.ipc = ipc;
+    }
+
+    /**
+     * Authorizes the requested operations.
+     *
+     * @param token token to validate server-side
+     * @throws AuthorizationException for any exceptions
+     */
+    public AuthorizationResponse validateToken(String token) throws AuthorizationException {
+        if (token == null) {
+            throw new AuthorizationException("Provided auth token is null");
+        } else if (token.isEmpty()) {
+            throw new AuthorizationException("Provided auth token is empty");
+        }
+        AuthorizationRequest request = AuthorizationRequest.builder().token(token).build();
+        return sendAndReceive(AuthorizationClientOpCodes.VALIDATE_TOKEN, request, AuthorizationResponse.class);
+    }
+
+    private <T> T sendAndReceive(AuthorizationClientOpCodes opCode, Object request, final Class<T> returnTypeClass)
+            throws AuthorizationException {
+        try {
+            CompletableFuture<T> responseFuture  = IPCUtil.sendAndReceive(ipc, AUTHORIZATION.getValue(),
+                    AUTHORIZATION_API_VERSION, opCode.ordinal(), request, returnTypeClass);
+            AuthorizationResponse authorizationResponse = (AuthorizationResponse) responseFuture.get();
+
+            if (!authorizationResponse.isAuthorized()) {
+                throw new AuthorizationException(authorizationResponse.getErrorMessage());
+            }
+            return responseFuture.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new AuthorizationException(String.format("Unable to authorize component due to error %s",
+                    e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationClientOpCodes.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationClientOpCodes.java
@@ -1,0 +1,5 @@
+package com.aws.iot.evergreen.ipc.authorization;
+
+public enum AuthorizationClientOpCodes {
+    VALIDATE_TOKEN;
+}

--- a/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationException.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationException.java
@@ -1,0 +1,12 @@
+package com.aws.iot.evergreen.ipc.authorization;
+
+public class AuthorizationException extends Exception {
+
+    public AuthorizationException(String message) {
+        super(message);
+    }
+
+    public AuthorizationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationRequest.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationRequest.java
@@ -1,0 +1,17 @@
+package com.aws.iot.evergreen.ipc.authorization;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Value;
+
+@Builder
+@Value
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+public class AuthorizationRequest {
+
+    @NonNull
+    private String token;
+}

--- a/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationResponse.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationResponse.java
@@ -1,0 +1,17 @@
+package com.aws.iot.evergreen.ipc.authorization;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorizationResponse {
+
+    @NonNull private boolean isAuthorized;
+    private String errorMessage;
+}

--- a/src/main/java/com/aws/iot/evergreen/ipc/common/BuiltInServiceDestinationCode.java
+++ b/src/main/java/com/aws/iot/evergreen/ipc/common/BuiltInServiceDestinationCode.java
@@ -6,7 +6,7 @@
 package com.aws.iot.evergreen.ipc.common;
 
 public enum BuiltInServiceDestinationCode {
-    AUTH(0), LIFECYCLE(1), SERVICE_DISCOVERY(2), CONFIG_STORE(3), PUBSUB(4), SECRET(5), ERROR(255);
+    AUTH(0), LIFECYCLE(1), SERVICE_DISCOVERY(2), CONFIG_STORE(3), PUBSUB(4), SECRET(5), AUTHORIZATION(6), ERROR(255);
 
     private final int value;
 

--- a/src/test/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationClientTest.java
+++ b/src/test/java/com/aws/iot/evergreen/ipc/authorization/AuthorizationClientTest.java
@@ -1,0 +1,150 @@
+package com.aws.iot.evergreen.ipc.authorization;
+
+import com.aws.iot.evergreen.ipc.IPCClient;
+import com.aws.iot.evergreen.ipc.IPCClientImpl;
+import com.aws.iot.evergreen.ipc.common.BuiltInServiceDestinationCode;
+import com.aws.iot.evergreen.ipc.common.FrameReader;
+import com.aws.iot.evergreen.ipc.common.FrameReader.MessageFrame;
+import com.aws.iot.evergreen.ipc.config.KernelIPCClientConfig;
+import com.aws.iot.evergreen.ipc.exceptions.IPCClientException;
+import com.aws.iot.evergreen.ipc.services.auth.AuthResponse;
+import com.aws.iot.evergreen.ipc.services.common.ApplicationMessage;
+import com.aws.iot.evergreen.ipc.services.common.IPCUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static com.aws.iot.evergreen.ipc.common.FrameReader.readFrame;
+import static com.aws.iot.evergreen.ipc.common.FrameReader.writeFrame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AuthorizationClientTest {
+
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    private IPCClient ipc;
+    private Socket sock;
+    private ServerSocket server;
+    private DataInputStream in;
+    private DataOutputStream out;
+    private int connectionCount = 0;
+
+    private AuthorizationClient authorizationClient;
+
+    private void writeMessageToSockOutputStream(int opCode, Integer requestId, Object data, FrameReader.FrameType type)
+            throws Exception {
+        ApplicationMessage transitionEventAppFrame =
+                ApplicationMessage.builder().version(AuthorizationClient.AUTHORIZATION_API_VERSION).opCode(opCode)
+                        .payload(IPCUtil.encode(data)).build();
+
+        int destination = BuiltInServiceDestinationCode.AUTHORIZATION.getValue();
+        FrameReader.Message message = new FrameReader.Message(transitionEventAppFrame.toByteArray());
+        MessageFrame messageFrame = requestId == null ? new MessageFrame(destination, message, type)
+                : new MessageFrame(requestId, destination, message, type);
+        writeFrame(messageFrame, out);
+    }
+
+    @BeforeEach
+    public void before() throws IOException, InterruptedException, IPCClientException {
+        server = new ServerSocket(0);
+        connectionCount = 0;
+        executor.submit(() -> {
+            while (true) {
+                sock = server.accept();
+                in = new DataInputStream(sock.getInputStream());
+                out = new DataOutputStream(sock.getOutputStream());
+
+                // Read and write auth
+                MessageFrame inFrame = readFrame(in);
+                ApplicationMessage requestApplicationFrame = ApplicationMessage.fromBytes(inFrame.message.getPayload());
+                AuthResponse authResponse = AuthResponse.builder().serviceName("ABC").clientId("test").build();
+                ApplicationMessage responsesAppFrame =
+                        ApplicationMessage.builder().version(requestApplicationFrame.getVersion())
+                                .payload(IPCUtil.encode(authResponse)).build();
+
+                writeFrame(new MessageFrame(inFrame.requestId, BuiltInServiceDestinationCode.AUTH.getValue(),
+                        new FrameReader.Message(responsesAppFrame.toByteArray()), FrameReader.FrameType.RESPONSE), out);
+                connectionCount++;
+            }
+        });
+
+        ipc = new IPCClientImpl(KernelIPCClientConfig.builder().port(server.getLocalPort()).build());
+        while (connectionCount == 0) {
+            Thread.sleep(10);
+        }
+    }
+
+    @AfterEach
+    public void after() throws IOException {
+        ipc.disconnect();
+        sock.close();
+        server.close();
+    }
+
+
+    @Test
+    public void GIVEN_authorized_token_WHEN_validating_token_THEN_succeed() throws AuthorizationException, ExecutionException, InterruptedException {
+
+        authorizationClient = new AuthorizationClient(ipc);
+
+        Future<?> fut = executor.submit(() -> {
+            MessageFrame inFrame = FrameReader.readFrame(in);
+            AuthorizationResponse successResponse = new AuthorizationResponse(true, null);
+            writeMessageToSockOutputStream(1, inFrame.requestId, successResponse, FrameReader.FrameType.RESPONSE);
+            return null;
+        });
+
+        AuthorizationResponse response = authorizationClient.validateToken("fakeToken");
+        assertTrue(response.isAuthorized());
+        assertNull(response.getErrorMessage());
+    }
+
+    @Test
+    public void GIVEN_unauthorized_token_WHEN_validating_token_THEN_throws() {
+
+        authorizationClient = new AuthorizationClient(ipc);
+
+        Future<?> fut = executor.submit(() -> {
+            MessageFrame inFrame = FrameReader.readFrame(in);
+            AuthorizationResponse successResponse = new AuthorizationResponse(false, "unauthorized token");
+            writeMessageToSockOutputStream(1, inFrame.requestId, successResponse, FrameReader.FrameType.RESPONSE);
+            return null;
+        });
+
+        final AuthorizationException ex
+                = assertThrows(AuthorizationException.class, () -> authorizationClient.validateToken("fakeToken"));
+        assertTrue(ex.getMessage().contains("unauthorized token"));
+    }
+
+    @Test
+    public void GIVEN_null_token_WHEN_validating_token_THEN_throws() {
+
+        authorizationClient = new AuthorizationClient(ipc);
+
+        final AuthorizationException ex
+                = assertThrows(AuthorizationException.class, () -> authorizationClient.validateToken(null));
+        assertTrue(ex.getMessage().contains("Provided auth token is null"));
+    }
+
+    @Test
+    public void GIVEN_empty_token_WHEN_validating_token_THEN_throws() {
+
+        authorizationClient = new AuthorizationClient(ipc);
+
+        final AuthorizationException ex
+                = assertThrows(AuthorizationException.class, () -> authorizationClient.validateToken(""));
+        assertTrue(ex.getMessage().contains("Provided auth token is empty"));
+    }
+}


### PR DESCRIPTION
**Description of changes:**
Addition of classes to create and publish authorization requests to the kernel IPC.

**Why is this change necessary:**
StreamManager will need to call this API when authorizing operations with Greengrass v2. This authorization request will be routed by the IPCRouter and then handled by a dedicated Authorization Service.

**How was this change tested:**
Built into AWSGreengrassGreenlake and then used StreamManager as a test component to send a request to the kernel IPC.
**Any additional information or context required to review the change:**
SDK Change: aws/aws-greengrass-sdk-java#48
Kernel change: https://github.com/aws/aws-greengrass-kernel/pull/375
StreamManager change: https://code.amazon.com/reviews/CR-32192357

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
