### PR TITLE
Replace String.format with StringBuilder.append

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/logging/impl/EvergreenStructuredLogMessage.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/EvergreenStructuredLogMessage.java
@@ -82,7 +82,8 @@ public class EvergreenStructuredLogMessage {
     @SuppressWarnings("checkstyle:emptycatchblock")
     public String getTextMessage() {
         // Create a new SDF every time because SDF isn't threadsafe
-        StringBuilder msg = new StringBuilder(new SimpleDateFormat("yyyy MMM dd hh:mm:ss,SSSZ").format(new Date(timestamp)));
+        StringBuilder msg = new StringBuilder(new SimpleDateFormat("yyyy MMM dd hh:mm:ss,SSSZ")
+                                              .format(new Date(timestamp)));
         // Equivalent to String.format("%s [%s] (%s) %s: %s", SDF, level, thread, loggerName, formattedMessage)
         msg.append(" [").append(level).append("] (")
                 .append(thread).append(") ")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Replace `String.format` with `StringBuilder.append` in `EvergreenStrucuturedLogMessage.getTextMessage()` to improve efficiencies. 

**Why is this change necessary:**
After running some JMH benchmarks, it's been discovered that using `StringBuilder.append` for `getTextMessage` is on average 1.7 times faster than using `String.format`, and the memory usage difference between them is negligible.
Hence it's an effective optimization to replace `String.format` with `StringBuilder.append`.

**How was this change tested:**
By unit test.

**Any additional information or context required to review the change:**
Detailed benchmark results are recorded here: https://quip-amazon.com/9b6lAAIpVrJb/Performance-benchmarks-of-StringBuilder-and-Stringformat

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
