### PR TITLE
Set Max History field in order for logback to delete oldest files.

### DIFF
--- a/src/main/java/com/aws/iot/evergreen/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/iot/evergreen/logging/impl/config/PersistenceConfig.java
@@ -272,6 +272,9 @@ public class PersistenceConfig {
 
         //TODO: Check how to make it rotate per x minutes.
 
+        // Max History is needed along with total cap size.
+        int maxHistory = Math.toIntExact((totalLogStoreSizeKB * FileSize.KB_COEFFICIENT)
+                / (fileSizeKB * FileSize.KB_COEFFICIENT));
         SizeAndTimeBasedRollingPolicy<ILoggingEvent> logFilePolicy = new SizeAndTimeBasedRollingPolicy<>();
         logFilePolicy.setContext(logCtx);
         logFilePolicy.setParent(fileAppender);
@@ -279,6 +282,7 @@ public class PersistenceConfig {
         logFilePolicy.setFileNamePattern(storeDirectory.resolve(fileName + "_%d{yyyy_MM_dd_HH}_%i" + "." + prefix)
                 .toString());
         logFilePolicy.setMaxFileSize(new FileSize(fileSizeKB * FileSize.KB_COEFFICIENT));
+        logFilePolicy.setMaxHistory(maxHistory);
         logFilePolicy.start();
 
         fileAppender.setRollingPolicy(logFilePolicy);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Max History is required for total cap size to work correctly.

**Why is this change necessary:**
Logs are not being deleted.

**How was this change tested:**
Made changes to LoggerDemo to ensure the oldest files are being deleted.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
