### PR TITLE
Detilde paths so it doesn't log to tilde

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/LogEventBuilderImpl.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/LogEventBuilderImpl.java
@@ -19,7 +19,7 @@ import java.util.function.Supplier;
 /**
  * An implementation of {@link LogEventBuilder} providing a fluent API to generate log events.
  */
-public class EGLogEventBuilder implements LogEventBuilder {
+public class LogEventBuilderImpl implements LogEventBuilder {
     private final Level level;
     private Throwable cause;
     private String eventType;
@@ -33,7 +33,7 @@ public class EGLogEventBuilder implements LogEventBuilder {
      * @param level             the log level setting on the logger
      * @param loggerContextData a map of key value pairs with contextual information for the logger
      */
-    public EGLogEventBuilder(Slf4jLogAdapter logger, Level level, Map<String, Object> loggerContextData) {
+    public LogEventBuilderImpl(Slf4jLogAdapter logger, Level level, Map<String, Object> loggerContextData) {
         this.logger = logger;
         this.level = level;
         eventContextData.putAll(loggerContextData);

--- a/src/main/java/com/aws/greengrass/logging/impl/Slf4jLogAdapter.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/Slf4jLogAdapter.java
@@ -158,7 +158,7 @@ public class Slf4jLogAdapter implements Logger {
                 context.putAll(loggerContextData);
             }
 
-            return new EGLogEventBuilder(this, logLevel, Collections.unmodifiableMap(context)).setCause(cause)
+            return new LogEventBuilderImpl(this, logLevel, Collections.unmodifiableMap(context)).setCause(cause)
                     .setEventType(eventType);
         }
         return LogEventBuilder.NOOP;
@@ -249,7 +249,7 @@ public class Slf4jLogAdapter implements Logger {
     }
 
     private void log(Level level, String msg, Object... args) {
-        new EGLogEventBuilder(this, level, Collections.unmodifiableMap(loggerContextData)).log(msg, args);
+        new LogEventBuilderImpl(this, level, Collections.unmodifiableMap(loggerContextData)).log(msg, args);
     }
 
     private String serialize(GreengrassLogMessage message) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Strip the `~/` from any paths and resolve it to the actual home directory.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
