### PR TITLE
Fix shading, switch to iso timestamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
@@ -276,6 +277,12 @@
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
+                            <artifactSet>
+                                <includes>
+                                    <include>ch.qos.logback:logback-classic:jar:*</include>
+                                    <include>com.aws.iot:evergreen-java-sdk:*</include>
+                                </includes>
+                            </artifactSet>
                             <filters>
                                 <filter>
                                     <!--
@@ -291,6 +298,9 @@
                                 </filter>
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic:jar:*</artifact>
+                                    <includes>
+                                        <include>**/*</include>
+                                    </includes>
                                     <excludes>
                                         <exclude>org/slf4j/impl/StaticLoggerBinder.class</exclude>
                                     </excludes>

--- a/src/main/java/com/aws/greengrass/logging/impl/GreengrassLogMessage.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/GreengrassLogMessage.java
@@ -16,9 +16,8 @@ import org.slf4j.event.Level;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.util.Date;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -41,8 +40,8 @@ public class GreengrassLogMessage {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     @JsonIgnore
     // Use ThreadLocal because SDFs are not threadsafe
-    private static final ThreadLocal<SimpleDateFormat> sdf = ThreadLocal.withInitial(
-            () -> new SimpleDateFormat("yyyy MMM dd HH:mm:ss,SSSZ"));
+    private static final ThreadLocal<DateTimeFormatter> sdf = ThreadLocal.withInitial(
+            () -> DateTimeFormatter.ISO_INSTANT);
 
     /**
      * Constructor for structured log message.
@@ -85,7 +84,7 @@ public class GreengrassLogMessage {
     @JsonIgnore
     @SuppressWarnings("checkstyle:emptycatchblock")
     public String getTextMessage() {
-        StringBuilder msg = new StringBuilder(sdf.get().format(new Date(timestamp)));
+        StringBuilder msg = new StringBuilder(sdf.get().format(Instant.ofEpochMilli(timestamp)));
         // Equivalent to String.format("%s [%s] (%s) %s: %s", SDF, level, thread, loggerName, formattedMessage)
         msg.append(" [").append(level).append("] (")
                 .append(thread).append(") ")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Change shading to only reshade logback, let other dependencies be excluded. Changing human-readable timestamp to use ISO 8601.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
