### PR TITLE
Fix file name during rotation.

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
@@ -234,7 +234,7 @@ public class PersistenceConfig {
     }
 
     protected synchronized void reconfigure(Logger loggerToConfigure) {
-        reconfigure(loggerToConfigure, fileName + "." + extension, totalLogStoreSizeKB, fileSizeKB);
+        reconfigure(loggerToConfigure, fileName, totalLogStoreSizeKB, fileSizeKB);
     }
 
     void reconfigure(Logger loggerToConfigure, String fileName, long totalLogStoreSizeKB, long fileSizeKB) {
@@ -280,7 +280,8 @@ public class PersistenceConfig {
                     logConsoleAppenders.getOrDefault(loggerToConfigure.getName(), null);
             final RollingFileAppender<ILoggingEvent> newLogFileAppender = getAppenderForFile(loggerToConfigure,
                     APPENDER_PREFIX + loggerToConfigure.getName(),
-                    storeDirectory.resolve(fileName).toString(), totalLogStoreSizeKB, fileSizeKB, fileName);
+                    storeDirectory.resolve(fileName + "." + extension).toString(), totalLogStoreSizeKB, fileSizeKB,
+                    fileName);
             newLogFileAppender.start();
             // Add the replacement
             loggerToConfigure.addAppender(newLogFileAppender);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
File rotation had an extra `.log` appended before the rotation regex.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
