### PR TITLE
Override ExecutorServiceUtil to reuse the same executor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,15 @@
                                         <exclude>org/slf4j/impl/StaticLoggerBinder.class</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>ch.qos.logback:logback-core:jar:*</artifact>
+                                    <includes>
+                                        <include>**/*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>ch/qos/logback/core/util</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                         </configuration>
                     </execution>
@@ -344,6 +353,15 @@
                                     </includes>
                                     <excludes>
                                         <exclude>org/slf4j/impl/StaticLoggerBinder.class</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>ch.qos.logback:logback-core:jar:*</artifact>
+                                    <includes>
+                                        <include>**/*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>ch/qos/logback/core/util</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/src/main/java/ch/qos/logback/core/util/ExecutorServiceUtil.java
+++ b/src/main/java/ch/qos/logback/core/util/ExecutorServiceUtil.java
@@ -1,0 +1,73 @@
+package ch.qos.logback.core.util;
+
+import ch.qos.logback.core.CoreConstants;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Static utility methods for manipulating an {@link ExecutorService}.
+ *
+ * @author Carl Harris
+ * @author Mikhail Mazursky
+ * @author Modified by AWS to reuse the same scheduled executor see {@link #newExecutorService()}
+ */
+public class ExecutorServiceUtil {
+
+    private static final ThreadFactory THREAD_FACTORY = new ThreadFactory() {
+
+        private final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+        public Thread newThread(Runnable r) {
+            Thread thread = defaultFactory.newThread(r);
+            if (!thread.isDaemon()) {
+                thread.setDaemon(true);
+            }
+            thread.setName("logback-" + threadNumber.getAndIncrement());
+            return thread;
+        }
+    };
+
+    private static ScheduledThreadPoolExecutor executor;
+
+    /**
+     * Creates a scheduled executor service suitable for use by logback components.
+     * @return scheduled executor service
+     */
+    public static synchronized ScheduledExecutorService newScheduledExecutorService() {
+        // This method has been modified from the original source in order to do two things.
+        // 1) Set the scheduled threadpool size to be 1. The original size was 8.
+        // 2) Cache and return the same executor so that there's a single threadpool in use to decrease
+        //  the number of threads which Logback creates.
+        if (executor == null || executor.isShutdown() || executor.isTerminated() || executor.isTerminating()) {
+            executor = new ScheduledThreadPoolExecutor(1, THREAD_FACTORY);
+        }
+        return executor;
+    }
+
+
+    /**
+     * Creates an executor service suitable for use by logback components.
+     * @return executor service
+     */
+    public static ExecutorService newExecutorService() {
+        return new ThreadPoolExecutor(CoreConstants.CORE_POOL_SIZE, CoreConstants.MAX_POOL_SIZE, 0L,
+                TimeUnit.MILLISECONDS, new SynchronousQueue<>(), THREAD_FACTORY);
+    }
+
+    /**
+     * Shuts down an executor service.
+     * @param executorService the executor service to shut down
+     */
+    public static void shutdown(ExecutorService executorService) {
+        executorService.shutdownNow();
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Override the ExecutorServiceUtil from Logback core so that it reuses the same executor for everything instead of creating new executors with a threadpool size of 8.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
