### PR TITLE
Remove reference to internal links

### DIFF
--- a/src/test/java/com/aws/greengrass/logging/impl/LoggerTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/LoggerTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-// TODO: write proper unit tests https://issues.amazon.com/issues/P31936029
 @ExtendWith(MockitoExtension.class)
 @Tag("Integration")
 class LoggerTest {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove references to internal links

**Why is this change necessary:**
Public git repo should not have references to amazon internal tools.

**How was this change tested:**
mvn package -DskipTests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
