### PR TITLE
Get log level from parent logger

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/Slf4jLogAdapter.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/Slf4jLogAdapter.java
@@ -193,8 +193,8 @@ public class Slf4jLogAdapter implements Logger {
         Level runningLevel = config.getLevel();
         if (individualLevel != null) {
             runningLevel = individualLevel;
-        } else if (parentLogger != null && parentLogger.individualLevel != null) {
-            runningLevel = parentLogger.individualLevel;
+        } else if (parentLogger != null) {
+            return parentLogger.isLogLevelEnabled(logLevel);
         }
         return runningLevel.toInt() <= logLevel.toInt();
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Get the log level by calling the parent recursively instead of only one level.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
