### PR TITLE
Fix LogConfig so that it gets the settings from the LoggerConfiguration

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
@@ -7,15 +7,16 @@ package com.aws.greengrass.logging.impl.config;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
+import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
 import lombok.Getter;
 import org.slf4j.event.Level;
 
+import java.nio.file.Paths;
 import java.util.Optional;
 
 @Getter
 public class LogConfig extends PersistenceConfig {
-    // TODO: Replace the default log level from Kernel Configuration.
     public static final String LOGS_DIRECTORY = "logs";
     public static final String LOG_FILE_EXTENSION = "log";
     private final LoggerContext context = new LoggerContext();
@@ -38,16 +39,22 @@ public class LogConfig extends PersistenceConfig {
     /**
      * Get default logging configuration from system properties.
      *
-     * @param loggerConfiguration   the configuration for the logger.
+     * @param loggerConfiguration the configuration for the logger.
      */
     public LogConfig(LoggerConfiguration loggerConfiguration) {
         super(LOG_FILE_EXTENSION, LOGS_DIRECTORY);
-        this.format = getInstance().getFormat();
-        this.store = getInstance().getStore();
-        this.storeDirectory = getInstance().getStoreDirectory();
+        LogManager.setEffectiveConfig(loggerConfiguration);
+        this.format = loggerConfiguration.getFormat();
+        this.store = loggerConfiguration.getOutputType();
+        if (loggerConfiguration.getOutputDirectory() == null) {
+            this.storeDirectory = getInstance().getStoreDirectory();
+        } else {
+            this.storeDirectory = Paths.get(deTilde(loggerConfiguration.getOutputDirectory()));
+        }
         Optional<String> fileNameWithoutExtension = stripExtension(loggerConfiguration.getFileName());
         this.fileName = fileNameWithoutExtension.orElseGet(() -> this.storeName);
         this.storeName = this.storeDirectory.resolve(loggerConfiguration.getFileName()).toAbsolutePath().toString();
+        this.level = loggerConfiguration.getLevel();
         reconfigure(context.getLogger(Logger.ROOT_LOGGER_NAME));
         startContext();
     }

--- a/src/test/java/com/aws/greengrass/logging/impl/config/LogConfigTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/config/LogConfigTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.logging.impl.config;
+
+import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
+
+import static com.aws.greengrass.logging.impl.config.PersistenceConfig.DEFAULT_STORE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LogConfigTest {
+    @AfterEach
+    void cleanup() {
+        LogConfig.getInstance().reset();
+    }
+
+
+    @Test
+    void GIVEN_provided_LoggerConfiguration_THEN_LogConfig_is_configured_the_same() {
+        LoggerConfiguration builder = LoggerConfiguration.builder().build();
+        LogConfig config = new LogConfig(builder);
+
+        assertEquals(LogStore.CONSOLE, config.getStore());
+        assertEquals(Level.INFO, config.getLevel());
+        assertEquals(LogFormat.TEXT, config.getFormat());
+        assertTrue(config.getStoreName().endsWith(DEFAULT_STORE_NAME));
+        assertEquals(DEFAULT_STORE_NAME, config.getFileName());
+
+        builder = LoggerConfiguration.builder().level(Level.TRACE).build();
+        config = new LogConfig(builder);
+
+        assertEquals(Level.TRACE, config.getLevel());
+
+        builder = LoggerConfiguration.builder().format(LogFormat.JSON).build();
+        config = new LogConfig(builder);
+
+        assertEquals(LogFormat.JSON, config.getFormat());
+
+        builder = LoggerConfiguration.builder().fileName("abc").build();
+        config = new LogConfig(builder);
+
+        assertTrue(config.getStoreName().endsWith("abc"));
+        assertEquals("abc", config.getFileName());
+    }
+
+    @Test
+    void GIVEN_provided_LoggerConfiguration_and_global_THEN_LogConfig_is_configured_with_merged() {
+        LogConfig root = LogConfig.getInstance();
+        root.setLevel(Level.DEBUG);
+        root.setFormat(LogFormat.JSON);
+
+        LoggerConfiguration builder = LoggerConfiguration.builder().build();
+        LogConfig config = new LogConfig(builder);
+
+        assertEquals(LogStore.CONSOLE, config.getStore());
+        assertEquals(Level.DEBUG, config.getLevel());
+        // This format is text because the default value in LoggerConfiguration builder is to use TEXT
+        assertEquals(LogFormat.TEXT, config.getFormat());
+        assertTrue(config.getStoreName().endsWith(DEFAULT_STORE_NAME));
+        assertEquals(DEFAULT_STORE_NAME, config.getFileName());
+
+        builder = LoggerConfiguration.builder().level(Level.TRACE).build();
+        config = new LogConfig(builder);
+
+        assertEquals(Level.TRACE, config.getLevel());
+
+        builder = LoggerConfiguration.builder().format(LogFormat.TEXT).build();
+        config = new LogConfig(builder);
+
+        assertEquals(LogFormat.TEXT, config.getFormat());
+
+        root.setStore(LogStore.FILE);
+        builder = LoggerConfiguration.builder().outputType(LogStore.CONSOLE).build();
+        config = new LogConfig(builder);
+
+        assertEquals(LogStore.CONSOLE, config.getStore());
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
LogConfig object was not actually reading all the properties from the `LoggerConfiguration` which is what is used to configure the `LogConfig` object. This PR fixes that as well as makes in inherit any missing configurations from the global config.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
