### PR TITLE
Fix reconfigureAllLoggers so that it actually sets the config even wh…

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
@@ -51,7 +51,6 @@ public class PersistenceConfig {
 
     @Getter
     protected final String extension;
-    @Setter
     protected LogStore store;
     protected String storeName;
     protected Path storeDirectory;
@@ -131,7 +130,7 @@ public class PersistenceConfig {
      *
      * @param store new store type
      */
-    public void setStoreType(LogStore store) {
+    public void setStore(LogStore store) {
         if (Objects.equals(this.store, store)) {
             return;
         }

--- a/src/main/java/com/aws/greengrass/logging/impl/config/model/LoggerConfiguration.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/model/LoggerConfiguration.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import org.slf4j.event.Level;
 
 import java.util.Objects;
@@ -22,6 +23,7 @@ import java.util.Objects;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class LoggerConfiguration {
     private Level level;
     private String fileName;

--- a/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
+++ b/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
@@ -116,7 +116,6 @@ public class TelemetryConfig extends PersistenceConfig {
             }
         }
         startContext();
-
     }
 
 


### PR DESCRIPTION
…en the output directory hasn't changed

**Issue #, if available:**

**Description of changes:**
Fixes `reconfigureAllLoggers` method so that it doesn't have any early `return` which was preventing it from actually reconfiguring our loggers as we needed.

**Why is this change necessary:**

**How was this change tested:**
Tested in UAT and unit test in https://github.com/aws/aws-greengrass-nucleus/pull/759

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
