### PR TITLE
fix(telemetry): Properly set the store directory when the root is cha…

### DIFF
--- a/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
+++ b/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
@@ -175,8 +175,9 @@ public class TelemetryConfig extends PersistenceConfig {
                 return;
             }
             root = newPath;
+            this.storeDirectory = root;
             closeContext();
-            //Reconfigure all the telemetry loggers to use the store at new path.
+            // Reconfigure all the telemetry loggers to use the store at new path.
             for (Logger logger : context.getLoggerList()) {
                 if (!logger.getName().equals("ROOT")) {
                     editConfigForLogger(logger.getName());


### PR DESCRIPTION
…nged in telemetry

**Issue #, if available:**

**Description of changes:**
Setting a new root directory did not change the store directory as is required, leading to the Nucleus (which calls `getStoreDirectory`) to try setting the permissions on the wrong directory.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
