### PR TITLE
Fix JSON format errors

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/GreengrassLogMessage.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/GreengrassLogMessage.java
@@ -139,7 +139,6 @@ public class GreengrassLogMessage {
                 throws IOException {
             jsonGenerator.writeStartObject();
             jsonGenerator.writeObjectField("message", throwable.getMessage());
-            jsonGenerator.writeObjectField("localizedMessage", throwable.getLocalizedMessage());
             jsonGenerator.writeObjectField("suppressed", throwable.getSuppressed());
             jsonGenerator.writeObjectField("stackTrace", throwable.getStackTrace());
             jsonGenerator.writeObjectField("cause", throwable.getCause());

--- a/src/main/java/com/aws/greengrass/logging/impl/GreengrassLogMessage.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/GreengrassLogMessage.java
@@ -6,8 +6,14 @@
 package com.aws.greengrass.logging.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -37,7 +43,9 @@ public class GreengrassLogMessage {
     private Throwable cause;
 
     @JsonIgnore
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                    .registerModule(new SimpleModule().addSerializer(new CustomThrowableSerializer(Throwable.class)));
     @JsonIgnore
     // Use ThreadLocal because SDFs are not threadsafe
     private static final ThreadLocal<DateTimeFormatter> sdf = ThreadLocal.withInitial(
@@ -115,7 +123,27 @@ public class GreengrassLogMessage {
         try {
             return OBJECT_MAPPER.writeValueAsString(this);
         } catch (JsonProcessingException e) {
-            return "{\"error\": \"" + e.getMessage() + "\"}";
+            return "{\"error\": \"" + new String(JsonStringEncoder.getInstance().quoteAsString(e.getMessage())) + "\"}";
+        }
+    }
+
+    private static class CustomThrowableSerializer extends StdSerializer<Throwable> {
+        private static final long serialVersionUID = 1L;  // required by spotbugs
+
+        protected CustomThrowableSerializer(Class<Throwable> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(Throwable throwable, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+                throws IOException {
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeObjectField("message", throwable.getMessage());
+            jsonGenerator.writeObjectField("localizedMessage", throwable.getLocalizedMessage());
+            jsonGenerator.writeObjectField("suppressed", throwable.getSuppressed());
+            jsonGenerator.writeObjectField("stackTrace", throwable.getStackTrace());
+            jsonGenerator.writeObjectField("cause", throwable.getCause());
+            jsonGenerator.writeEndObject();
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/telemetry/impl/TelemetryLoggerMessage.java
+++ b/src/main/java/com/aws/greengrass/telemetry/impl/TelemetryLoggerMessage.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.telemetry.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
 
@@ -28,7 +29,7 @@ public class TelemetryLoggerMessage {
         try {
             return OBJECT_MAPPER.writeValueAsString(this.metricDataPoint);
         } catch (JsonProcessingException e) {
-            return "{\"error\": \"" + e.getMessage() + "\"}";
+            return "{\"error\": \"" + new String(JsonStringEncoder.getInstance().quoteAsString(e.getMessage())) + "\"}";
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/telemetry/impl/TelemetryLoggerMessage.java
+++ b/src/main/java/com/aws/greengrass/telemetry/impl/TelemetryLoggerMessage.java
@@ -9,11 +9,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import lombok.Data;
 
 @Data
 public class TelemetryLoggerMessage {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     private Object metricDataPoint;
 
     public TelemetryLoggerMessage(Object metricDataPoint) {

--- a/src/test/java/com/aws/greengrass/logging/impl/StructuredLayoutTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/StructuredLayoutTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.logging.impl;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -19,11 +20,13 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StructuredLayoutTest {
-    private static final ObjectMapper JSON_MAPPER = new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+            .addMixIn(Throwable.class, ThrowableMixin.class);
 
     @Test
     public void GIVEN_json_appender_WHEN_write_log_events_THEN_events_are_json_encoded() throws IOException {
@@ -31,7 +34,7 @@ public class StructuredLayoutTest {
                 new GreengrassLogMessage("Logger", Level.INFO, "eventType", "message 1",
                         new HashMap<String, String>() {{
                             put("key", "value");
-                        }}, new Exception("EX!", new Exception("the \"cause\""))),
+                        }}, new Exception("EX!")),
                 new GreengrassLogMessage("Logger", Level.INFO, "eventType", "message 1", null, null),
                 new GreengrassLogMessage("Logger", Level.INFO, null, "message 1",
                         new HashMap<String, String>() {{
@@ -52,7 +55,7 @@ public class StructuredLayoutTest {
             if (message.getCause() == null) {
                 assertNull(deserializedMessage.getCause());
             } else {
-                assertEquals(message.getCause().getMessage(), deserializedMessage.getCause().getMessage());
+                assertThrowableEquals(message.getCause(), deserializedMessage.getCause());
             }
         }
         assertEquals(
@@ -80,32 +83,85 @@ public class StructuredLayoutTest {
     }
 
     @Test
-    public void GIVEN_throwable_that_fails_default_serializer_WHEN_log_it_THEN_custom_serializer_succeeds()
+    public void GIVEN_throwable_that_fails_default_serializer_WHEN_use_custom_serializer_THEN_succeeds()
             throws JsonProcessingException {
-        try {
-            // This will throw an exception that cannot be serialized successfully by Jackson's default serializer
-            JSON_MAPPER.readValue("this will go wrong", Object.class);
-            fail("Expected to raise exception");
-        } catch (Throwable e) {
-            try {
-                JSON_MAPPER.writeValueAsString(e);
-                fail("Expected default serializer to fail");
-            } catch (Exception ignore) {
-                // do nothing
-            }
-            GreengrassLogMessage message = new GreengrassLogMessage();
-            message.setMessage("testing");
-            message.setCause(e);
-            GreengrassLogMessage messageDeserialized =
-                    JSON_MAPPER.readValue(message.getJSONMessage(), GreengrassLogMessage.class);
-            assertEquals(message, messageDeserialized);
+        Throwable cause = assertThrows(JsonProcessingException.class,
+                () -> JSON_MAPPER.readValue("this will go wrong", Object.class));
 
-            Throwable deserializedCause = messageDeserialized.getCause();
-            assertEquals(e.getMessage(), deserializedCause.getMessage());
-            assertEquals(e.getLocalizedMessage(), deserializedCause.getLocalizedMessage());
-            assertEquals(e.getCause(), deserializedCause.getCause());
-            assertArrayEquals(e.getSuppressed(), deserializedCause.getSuppressed());
-            assertArrayEquals(e.getStackTrace(), deserializedCause.getStackTrace());
+        // Default serializer should fail to serialize this throwable
+        assertThrows(JsonProcessingException.class, () -> JSON_MAPPER.writeValueAsString(cause));
+
+        GreengrassLogMessage message = new GreengrassLogMessage();
+        message.setMessage("testing");
+        message.setCause(cause);
+        GreengrassLogMessage messageDeserialized =
+                JSON_MAPPER.readValue(message.getJSONMessage(), GreengrassLogMessage.class);
+        assertEquals(message, messageDeserialized);
+
+        Throwable deserializedCause = messageDeserialized.getCause();
+        assertThrowableEquals(cause, deserializedCause);
+    }
+
+    @Test
+    public void GIVEN_message_WHEN_serialize_and_deserialize_THEN_throwable_fields_handled_properly()
+            throws JsonProcessingException {
+        String baseMessage = "base";
+        String causeMessage = "cause with \"quotes\"";  // test that quotes are escaped properly
+        Throwable base = new ThrowableWithExtra(baseMessage);
+        Throwable suppressed = new ThrowableWithExtra("suppressed");
+        Throwable cause = new ThrowableWithExtra(causeMessage);
+        base.initCause(cause);
+        base.addSuppressed(suppressed);
+        cause.addSuppressed(suppressed);
+
+        GreengrassLogMessage message = new GreengrassLogMessage();
+        message.setMessage("testing");
+        message.setCause(base);
+        String jsonMessage = message.getJSONMessage();
+        // check no extra fields serialized
+        assertFalse(jsonMessage.contains("\"extra\""));
+
+        Throwable deserializedCause = JSON_MAPPER.readValue(jsonMessage, GreengrassLogMessage.class).getCause();
+        assertThrowableEquals(base, deserializedCause);
+        // check no extra fields deserialized in the throwable itself, suppressed, and cause
+        assertThrows(NoSuchFieldException.class, () -> deserializedCause.getClass().getField("extra"));
+        assertThrows(NoSuchFieldException.class,
+                () -> deserializedCause.getSuppressed()[0].getClass().getField("extra"));
+        assertThrows(NoSuchFieldException.class, () -> deserializedCause.getCause().getClass().getField("extra"));
+    }
+
+    /**
+     * Assert that two Throwables equal on fields that we care about
+     */
+    private static void assertThrowableEquals(Throwable expected, Throwable actual) {
+        if (expected == null) {
+            assertNull(actual);
+            return;
         }
+        assertEquals(expected.getMessage(), actual.getMessage());
+        assertArrayEquals(expected.getStackTrace(), actual.getStackTrace());
+        assertThrowableEquals(expected.getCause(), actual.getCause());
+
+        assertEquals(expected.getSuppressed().length, actual.getSuppressed().length);
+        for (int i = 0; i < expected.getSuppressed().length; i++) {
+            assertThrowableEquals(expected.getSuppressed()[i], actual.getSuppressed()[i]);
+        }
+    }
+
+    private static class ThrowableWithExtra extends Throwable {
+        public String extra;
+        ThrowableWithExtra(String extra) {
+            super(extra);
+            this.extra = extra;
+        }
+    }
+
+    /**
+     * Java's Throwable.suppressedExceptions naming is inconsistent with its getter (getSuppressed)
+     * This mixin is required for Jackson to deserialize it properly
+     */
+    private static abstract class ThrowableMixin {
+        @JsonProperty("suppressed")
+        List<Throwable> suppressedExceptions;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-nucleus/issues/847

**Description of changes:**
For `GreengrassLogMessage`:
- Use custom serializer on `Throwable` to prevent serialization of irrelevant fields, which can cause the serialization to fail (for an example of this kind of failure, see the original issue report and the added unit test).

`GreengrassLogMessage` and `TelemetryLoggerMessage`:
- Disable fail on empty beans
- Properly escape error message string when serialization fails

**Why is this change necessary:**
Makes JSON logging more robust.

**How was this change tested:**
Added new unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
