### PR TITLE
fix(logging): config not applied to component logger. support reset

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/examples/LoggerDemo.java
+++ b/src/main/java/com/aws/greengrass/logging/examples/LoggerDemo.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.logging.examples;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -29,10 +29,10 @@ public class LoggerDemo {
         logger1 = LogManager.getLogger(LoggerDemo.class);
         randomNewLogger = LogManager.getLogger("RandomNewLogger");
         logger1Child = logger1.createChild();
-        LoggerConfiguration loggerConfiguration = LoggerConfiguration.builder()
+        LogConfigUpdate logConfigUpdate = LogConfigUpdate.builder()
                 .fileName("testComponent/testLog.log")
                 .build();
-        logger2 = LogManager.getLogger("newLogger", loggerConfiguration);
+        logger2 = LogManager.getLogger("newLogger", logConfigUpdate);
         logger2Child = logger2.createChild();
         logger1.addDefaultKeyValue("component", "demo").addDefaultKeyValue("device", "asdf");
     }

--- a/src/main/java/com/aws/greengrass/logging/impl/LogManager.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/LogManager.java
@@ -132,25 +132,28 @@ public class LogManager {
         if (resetTopicName == null) {  // reset all to default
             reconfigureAllLoggers(new LogConfigUpdate(defaultConfig));
         } else {  // reset individual config
-            LogConfigUpdate configToApply = LogConfigUpdate.builder().build();
+            LogConfigUpdate configToApply;
             switch (resetTopicName) {
                 case "level":
-                    configToApply.setLevel(defaultConfig.getLevel());
+                    configToApply = LogConfigUpdate.builder().level(defaultConfig.getLevel()).build();
                     break;
                 case "format":
-                    configToApply.setFormat(defaultConfig.getFormat());
+                    configToApply = LogConfigUpdate.builder().format(defaultConfig.getFormat()).build();
                     break;
                 case "outputType":
-                    configToApply.setOutputType(defaultConfig.getStore());
+                    configToApply = LogConfigUpdate.builder().outputType(defaultConfig.getStore()).build();
                     break;
                 case "fileSizeKB":
-                    configToApply.setFileSizeKB(defaultConfig.getFileSizeKB());
+                    configToApply = LogConfigUpdate.builder().fileSizeKB(defaultConfig.getFileSizeKB()).build();
                     break;
                 case "totalLogsSizeKB":
-                    configToApply.setTotalLogsSizeKB(defaultConfig.getTotalLogStoreSizeKB());
+                    configToApply =
+                            LogConfigUpdate.builder().totalLogsSizeKB(defaultConfig.getTotalLogStoreSizeKB()).build();
                     break;
                 case "outputDirectory":
-                    configToApply.setOutputDirectory(defaultConfig.getStoreDirectory().toString());
+                    configToApply =
+                            LogConfigUpdate.builder().outputDirectory(defaultConfig.getStoreDirectory().toString())
+                                    .build();
                     break;
                 default:
                     // Unknown config topic. Do nothing
@@ -203,12 +206,12 @@ public class LogManager {
         }
     }
 
-    private static void setLogConfig(LogConfig log, LogConfigUpdate config) {
-        if (config.getLevel() != null) {
-            log.setLevel(config.getLevel());
+    private static void setLogConfig(LogConfig log, LogConfigUpdate configUpdate) {
+        if (configUpdate.getLevel() != null) {
+            log.setLevel(configUpdate.getLevel());
         }
-        if (config.getFormat() != null) {
-            log.setFormat(config.getFormat());
+        if (configUpdate.getFormat() != null) {
+            log.setFormat(configUpdate.getFormat());
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/logging/impl/LogManager.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/LogManager.java
@@ -34,7 +34,7 @@ public class LogManager {
     private static final ConcurrentMap<String, com.aws.greengrass.logging.api.Logger> telemetryLoggerMap =
             new ConcurrentHashMap<>();
     @Getter
-    private static final LogConfig rootLogConfiguration = LogConfig.getInstance();
+    private static final LogConfig rootLogConfiguration = LogConfig.getRootLogConfig();
     @Getter
     private static final Map<String, LogConfig> logConfigurations = new ConcurrentHashMap<>();
     @Getter
@@ -101,7 +101,7 @@ public class LogManager {
      */
     public static void setRoot(Path newPath) {
         if (newPath != null) {
-            LogConfig rootConfig = LogConfig.getInstance();
+            LogConfig rootConfig = LogConfig.getRootLogConfig();
             newPath = Paths.get(rootConfig.deTilde(newPath.resolve(LOGS_DIRECTORY).toString()));
             if (Objects.equals(rootLogConfiguration.getStoreDirectory(), newPath)) {
                 return;

--- a/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
@@ -42,11 +42,11 @@ public class LogConfig extends PersistenceConfig {
     /**
      * Create a new instance of LogConfig by inheriting configs from current root config.
      *
-     * @param configUpdate parameters to override the root config
+     * @param configOverrides parameters to override the root config
      * @return a new instance of LogConfig
      */
-    public static LogConfig newLogConfigFromRootConfig(LogConfigUpdate configUpdate) {
-        fillNullFieldsFromRootConfig(configUpdate);
+    public static LogConfig newLogConfigFromRootConfig(LogConfigUpdate configOverrides) {
+        LogConfigUpdate configUpdate = fillNullFieldsFromRootConfig(configOverrides);
         LogConfig newConfig = new LogConfig();
         newConfig.format = configUpdate.getFormat();
         newConfig.store = configUpdate.getOutputType();
@@ -65,33 +65,38 @@ public class LogConfig extends PersistenceConfig {
     }
 
     /**
-     * If a field is null in the given configUpdate, set it using the value from root logging config.
-     * Effectively inheriting the root config
+     * Create a new LogConfigUpdate from current root config, but override it with the given configUpdate.
+     * Effectively inheriting the root config with overrides.
+     *
+     * @param configOverrides params to override the root config
+     * @return a new instance of LogConfigUpdate
      */
-    private static void fillNullFieldsFromRootConfig(LogConfigUpdate configUpdate) {
+    private static LogConfigUpdate fillNullFieldsFromRootConfig(LogConfigUpdate configOverrides) {
         LogConfig rootLogConfiguration = LogManager.getRootLogConfiguration();
-        if (configUpdate.getFileName() == null || configUpdate.getFileName().trim().isEmpty()) {
-            configUpdate.setFileName(rootLogConfiguration.getFileName());
+        LogConfigUpdate.LogConfigUpdateBuilder newConfigUpdate = configOverrides.toBuilder();
+        if (configOverrides.getFileName() == null || configOverrides.getFileName().trim().isEmpty()) {
+            newConfigUpdate.fileName(rootLogConfiguration.getFileName());
         }
-        if (configUpdate.getFileSizeKB() == null) {
-            configUpdate.setFileSizeKB(rootLogConfiguration.getFileSizeKB());
+        if (configOverrides.getFileSizeKB() == null) {
+            newConfigUpdate.fileSizeKB(rootLogConfiguration.getFileSizeKB());
         }
-        if (configUpdate.getTotalLogsSizeKB() == null) {
-            configUpdate.setTotalLogsSizeKB(rootLogConfiguration.getTotalLogStoreSizeKB());
+        if (configOverrides.getTotalLogsSizeKB() == null) {
+            newConfigUpdate.totalLogsSizeKB(rootLogConfiguration.getTotalLogStoreSizeKB());
         }
-        if (configUpdate.getFormat() == null) {
-            configUpdate.setFormat(rootLogConfiguration.getFormat());
+        if (configOverrides.getFormat() == null) {
+            newConfigUpdate.format(rootLogConfiguration.getFormat());
         }
-        if (configUpdate.getLevel() == null) {
-            configUpdate.setLevel(rootLogConfiguration.getLevel());
+        if (configOverrides.getLevel() == null) {
+            newConfigUpdate.level(rootLogConfiguration.getLevel());
         }
-        if (configUpdate.getOutputType() == null) {
-            configUpdate.setOutputType(rootLogConfiguration.getStore());
+        if (configOverrides.getOutputType() == null) {
+            newConfigUpdate.outputType(rootLogConfiguration.getStore());
         }
-        if (configUpdate.getOutputDirectory() == null && LogStore.FILE
-                .equals(configUpdate.getOutputType())) {
-            configUpdate.setOutputDirectory(rootLogConfiguration.getStoreDirectory().toString());
+        if (configOverrides.getOutputDirectory() == null && LogStore.FILE
+                .equals(configOverrides.getOutputType())) {
+            newConfigUpdate.outputDirectory(rootLogConfiguration.getStoreDirectory().toString());
         }
+        return newConfigUpdate.build();
     }
 
     public Logger getLogger(String name) {

--- a/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
@@ -23,6 +23,9 @@ public class LogConfig extends PersistenceConfig {
 
     private static final LogConfig INSTANCE = new LogConfig();
 
+    /**
+     * This is the root logger configuration. Child loggers may refer to this to find default config values
+     */
     public static LogConfig getInstance() {
         return INSTANCE;
     }
@@ -43,7 +46,7 @@ public class LogConfig extends PersistenceConfig {
      */
     public LogConfig(LoggerConfiguration loggerConfiguration) {
         super(LOG_FILE_EXTENSION, LOGS_DIRECTORY);
-        LogManager.setEffectiveConfig(loggerConfiguration);
+        LogManager.setNullFieldsFromRootConfig(loggerConfiguration);
         this.format = loggerConfiguration.getFormat();
         this.store = loggerConfiguration.getOutputType();
         if (loggerConfiguration.getOutputDirectory() == null) {

--- a/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
@@ -21,13 +21,13 @@ public class LogConfig extends PersistenceConfig {
     public static final String LOG_FILE_EXTENSION = "log";
     private final LoggerContext context = new LoggerContext();
 
-    private static final LogConfig INSTANCE = new LogConfig();
+    private static final LogConfig ROOT_LOG_CONFIG = new LogConfig();
 
     /**
      * This is the root logger configuration. Child loggers may refer to this to find default config values
      */
-    public static LogConfig getInstance() {
-        return INSTANCE;
+    public static LogConfig getRootLogConfig() {
+        return ROOT_LOG_CONFIG;
     }
 
     /**
@@ -51,7 +51,7 @@ public class LogConfig extends PersistenceConfig {
         newConfig.format = configUpdate.getFormat();
         newConfig.store = configUpdate.getOutputType();
         if (configUpdate.getOutputDirectory() == null) {
-            newConfig.storeDirectory = getInstance().getStoreDirectory();
+            newConfig.storeDirectory = getRootLogConfig().getStoreDirectory();
         } else {
             newConfig.storeDirectory = Paths.get(deTilde(configUpdate.getOutputDirectory()));
         }

--- a/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
@@ -9,6 +9,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.OutputStreamAppender;
 import ch.qos.logback.core.encoder.EncoderBase;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
@@ -239,15 +240,28 @@ public class PersistenceConfig {
     /**
      * Reconfigures the logger based on the logger configuration provided.
      * @param loggerConfiguration   The configuration for the logger.
+     *                              Can be a partial config. The null fields are ignored
      * @param storePath             Ths output directory path.
      */
     public synchronized void reconfigure(LoggerConfiguration loggerConfiguration, Path storePath) {
-        level = loggerConfiguration.getLevel();
-        store = loggerConfiguration.getOutputType();
-        format = loggerConfiguration.getFormat();
-        fileName = loggerConfiguration.getFileName();
-        fileSizeKB = loggerConfiguration.getFileSizeKB();
-        totalLogStoreSizeKB = loggerConfiguration.getTotalLogsSizeKB();
+        if (loggerConfiguration.getLevel() != null) {
+            level = loggerConfiguration.getLevel();
+        }
+        if (loggerConfiguration.getOutputType() != null) {
+            store = loggerConfiguration.getOutputType();
+        }
+        if (loggerConfiguration.getFormat() != null) {
+            format = loggerConfiguration.getFormat();
+        }
+        if (loggerConfiguration.getFileName() != null) {
+            fileName = loggerConfiguration.getFileName();
+        }
+        if (loggerConfiguration.getFileSizeKB() != null) {
+            fileSizeKB = loggerConfiguration.getFileSizeKB();
+        }
+        if (loggerConfiguration.getTotalLogsSizeKB() != null) {
+            totalLogStoreSizeKB = loggerConfiguration.getTotalLogsSizeKB();
+        }
         setStoreDirectory(storePath);
         reconfigure();
     }

--- a/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
@@ -9,12 +9,11 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
-import ch.qos.logback.core.OutputStreamAppender;
 import ch.qos.logback.core.encoder.EncoderBase;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
 import ch.qos.logback.core.util.FileSize;
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
 import lombok.Setter;
@@ -196,7 +195,7 @@ public class PersistenceConfig {
      * @param path  The path to transform.
      * @return transformed path without the "~".
      */
-    public String deTilde(String path) {
+    public static String deTilde(String path) {
         // Get path if "~/" is used
         if (path.startsWith(HOME_DIR_PREFIX)) {
             return Paths.get(System.getProperty("user.home"))
@@ -214,7 +213,7 @@ public class PersistenceConfig {
         }
     }
 
-    protected Optional<String> stripExtension(String fileName) {
+    protected static Optional<String> stripExtension(String fileName) {
         // Handle null case specially.
         if (fileName == null) {
             return Optional.empty();
@@ -239,28 +238,28 @@ public class PersistenceConfig {
 
     /**
      * Reconfigures the logger based on the logger configuration provided.
-     * @param loggerConfiguration   The configuration for the logger.
+     * @param logConfigUpdate   The configuration for the logger.
      *                              Can be a partial config. The null fields are ignored
      * @param storePath             Ths output directory path.
      */
-    public synchronized void reconfigure(LoggerConfiguration loggerConfiguration, Path storePath) {
-        if (loggerConfiguration.getLevel() != null) {
-            level = loggerConfiguration.getLevel();
+    public synchronized void reconfigure(LogConfigUpdate logConfigUpdate, Path storePath) {
+        if (logConfigUpdate.getLevel() != null) {
+            level = logConfigUpdate.getLevel();
         }
-        if (loggerConfiguration.getOutputType() != null) {
-            store = loggerConfiguration.getOutputType();
+        if (logConfigUpdate.getOutputType() != null) {
+            store = logConfigUpdate.getOutputType();
         }
-        if (loggerConfiguration.getFormat() != null) {
-            format = loggerConfiguration.getFormat();
+        if (logConfigUpdate.getFormat() != null) {
+            format = logConfigUpdate.getFormat();
         }
-        if (loggerConfiguration.getFileName() != null) {
-            fileName = loggerConfiguration.getFileName();
+        if (logConfigUpdate.getFileName() != null) {
+            fileName = logConfigUpdate.getFileName();
         }
-        if (loggerConfiguration.getFileSizeKB() != null) {
-            fileSizeKB = loggerConfiguration.getFileSizeKB();
+        if (logConfigUpdate.getFileSizeKB() != null) {
+            fileSizeKB = logConfigUpdate.getFileSizeKB();
         }
-        if (loggerConfiguration.getTotalLogsSizeKB() != null) {
-            totalLogStoreSizeKB = loggerConfiguration.getTotalLogsSizeKB();
+        if (logConfigUpdate.getTotalLogsSizeKB() != null) {
+            totalLogStoreSizeKB = logConfigUpdate.getTotalLogsSizeKB();
         }
         setStoreDirectory(storePath);
         reconfigure();

--- a/src/main/java/com/aws/greengrass/logging/impl/config/model/LogConfigUpdate.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/model/LogConfigUpdate.java
@@ -14,10 +14,13 @@ import lombok.Data;
 import org.slf4j.event.Level;
 
 
+/**
+ * Data transfer object for passing around log config parameters.
+ */
 @Builder
 @Data
 @AllArgsConstructor
-public class LoggerConfiguration {
+public class LogConfigUpdate {
     private Level level;
     private String fileName;
     private Long fileSizeKB;
@@ -30,7 +33,7 @@ public class LoggerConfiguration {
      * Construct from a PersistenceConfig by reading the config values from it.
      * @param persistenceConfig a PersistenceConfig object
      */
-    public LoggerConfiguration(PersistenceConfig persistenceConfig) {
+    public LogConfigUpdate(PersistenceConfig persistenceConfig) {
         level = persistenceConfig.getLevel();
         fileName = persistenceConfig.getFileName();
         fileSizeKB = persistenceConfig.getFileSizeKB();

--- a/src/main/java/com/aws/greengrass/logging/impl/config/model/LogConfigUpdate.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/model/LogConfigUpdate.java
@@ -10,24 +10,28 @@ import com.aws.greengrass.logging.impl.config.LogStore;
 import com.aws.greengrass.logging.impl.config.PersistenceConfig;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 import org.slf4j.event.Level;
 
 
 /**
  * Data transfer object for passing around log config parameters.
  */
-@Builder
-@Data
+@Builder(toBuilder = true)
+@ToString
+@EqualsAndHashCode
+@Getter
 @AllArgsConstructor
 public class LogConfigUpdate {
-    private Level level;
-    private String fileName;
-    private Long fileSizeKB;
-    private Long totalLogsSizeKB;
-    private LogFormat format;
-    private String outputDirectory;
-    private LogStore outputType;
+    private final Level level;
+    private final String fileName;
+    private final Long fileSizeKB;
+    private final Long totalLogsSizeKB;
+    private final LogFormat format;
+    private final String outputDirectory;
+    private final LogStore outputType;
 
     /**
      * Construct from a PersistenceConfig by reading the config values from it.

--- a/src/main/java/com/aws/greengrass/logging/impl/config/model/LoggerConfiguration.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/model/LoggerConfiguration.java
@@ -7,60 +7,36 @@ package com.aws.greengrass.logging.impl.config.model;
 
 import com.aws.greengrass.logging.impl.config.LogFormat;
 import com.aws.greengrass.logging.impl.config.LogStore;
+import com.aws.greengrass.logging.impl.config.PersistenceConfig;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.Data;
 import org.slf4j.event.Level;
 
-import java.util.Objects;
 
-
-@Getter
-@Setter
 @Builder
-@NoArgsConstructor
+@Data
 @AllArgsConstructor
-@ToString
 public class LoggerConfiguration {
     private Level level;
     private String fileName;
-    @Builder.Default
-    private long fileSizeKB = -1;
-    @Builder.Default
-    private long totalLogsSizeKB = -1;
-    @Builder.Default
-    private LogFormat format = LogFormat.TEXT;
-    private LogStore outputType;
+    private Long fileSizeKB;
+    private Long totalLogsSizeKB;
+    private LogFormat format;
     private String outputDirectory;
+    private LogStore outputType;
 
-    @Override
-    public boolean equals(Object o) {
-        // If the object is compared with itself then return true
-        if (o == this) {
-            return true;
-        }
-        /* Check if o is an instance of LoggerConfiguration or not "null instanceof [type]" also returns false */
-        if (!(o instanceof LoggerConfiguration)) {
-            return false;
-        }
-
-        // typecast o to LoggerConfiguration so that we can compare data members
-        LoggerConfiguration newConfiguration = (LoggerConfiguration) o;
-
-        // Compare the data members and return accordingly
-        return Objects.equals(this.level, newConfiguration.level)
-                && Objects.equals(this.format, newConfiguration.format)
-                && Objects.equals(this.outputType, newConfiguration.outputType)
-                && this.fileSizeKB == newConfiguration.fileSizeKB
-                && this.totalLogsSizeKB == newConfiguration.totalLogsSizeKB
-                && Objects.equals(this.outputDirectory, newConfiguration.outputDirectory);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
+    /**
+     * Construct from a PersistenceConfig by reading the config values from it.
+     * @param persistenceConfig a PersistenceConfig object
+     */
+    public LoggerConfiguration(PersistenceConfig persistenceConfig) {
+        level = persistenceConfig.getLevel();
+        fileName = persistenceConfig.getFileName();
+        fileSizeKB = persistenceConfig.getFileSizeKB();
+        totalLogsSizeKB = persistenceConfig.getTotalLogStoreSizeKB();
+        format = persistenceConfig.getFormat();
+        outputDirectory = persistenceConfig.getStoreDirectory().toString();
+        outputType = persistenceConfig.getStore();
     }
 }

--- a/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
+++ b/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
@@ -12,7 +12,7 @@ import ch.qos.logback.core.rolling.RollingFileAppender;
 import com.aws.greengrass.logging.impl.config.LogFormat;
 import com.aws.greengrass.logging.impl.config.LogStore;
 import com.aws.greengrass.logging.impl.config.PersistenceConfig;
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import lombok.Getter;
 import lombok.Setter;
 import org.slf4j.event.Level;
@@ -100,19 +100,19 @@ public class TelemetryConfig extends PersistenceConfig {
      * Reconfigures the logger based on the logger configuration provided. Overriding this since we don't want
      * to change the telemetry directory or file name.
      *
-     * @param loggerConfiguration   The configuration for the logger.
+     * @param logConfigUpdate   The configuration for the logger.
      * @param storePath             Ths output directory path.
      */
     @Override
-    public synchronized void reconfigure(LoggerConfiguration loggerConfiguration, Path storePath) {
-        if (loggerConfiguration.getOutputType() != null) {
-            store = loggerConfiguration.getOutputType();
+    public synchronized void reconfigure(LogConfigUpdate logConfigUpdate, Path storePath) {
+        if (logConfigUpdate.getOutputType() != null) {
+            store = logConfigUpdate.getOutputType();
         }
-        if (loggerConfiguration.getFileSizeKB() != null) {
-            fileSizeKB = loggerConfiguration.getFileSizeKB();
+        if (logConfigUpdate.getFileSizeKB() != null) {
+            fileSizeKB = logConfigUpdate.getFileSizeKB();
         }
-        if (loggerConfiguration.getTotalLogsSizeKB() != null) {
-            totalLogStoreSizeKB = loggerConfiguration.getTotalLogsSizeKB();
+        if (logConfigUpdate.getTotalLogsSizeKB() != null) {
+            totalLogStoreSizeKB = logConfigUpdate.getTotalLogsSizeKB();
         }
         closeContext();
         //Reconfigure all the telemetry loggers to use the store at new path.

--- a/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
+++ b/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
@@ -105,9 +105,15 @@ public class TelemetryConfig extends PersistenceConfig {
      */
     @Override
     public synchronized void reconfigure(LoggerConfiguration loggerConfiguration, Path storePath) {
-        store = loggerConfiguration.getOutputType();
-        fileSizeKB = loggerConfiguration.getFileSizeKB();
-        totalLogStoreSizeKB = loggerConfiguration.getTotalLogsSizeKB();
+        if (loggerConfiguration.getOutputType() != null) {
+            store = loggerConfiguration.getOutputType();
+        }
+        if (loggerConfiguration.getFileSizeKB() != null) {
+            fileSizeKB = loggerConfiguration.getFileSizeKB();
+        }
+        if (loggerConfiguration.getTotalLogsSizeKB() != null) {
+            totalLogStoreSizeKB = loggerConfiguration.getTotalLogsSizeKB();
+        }
         closeContext();
         //Reconfigure all the telemetry loggers to use the store at new path.
         for (Logger logger : context.getLoggerList()) {

--- a/src/test/java/com/aws/greengrass/logging/impl/FileLoggerTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/FileLoggerTest.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.logging.impl;
 
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.config.LogStore;
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -83,7 +83,7 @@ class FileLoggerTest {
         String randomLoggerName = UUID.randomUUID().toString();
         String randomString = UUID.randomUUID().toString();
         LogManager.setRoot(tempRootDir.resolve(randomFolder).toAbsolutePath());
-        Logger logger2 = LogManager.getLogger(randomLoggerName, LoggerConfiguration.builder()
+        Logger logger2 = LogManager.getLogger(randomLoggerName, LogConfigUpdate.builder()
                 .fileName(randomLogFileName)
                 .build());
 
@@ -110,7 +110,7 @@ class FileLoggerTest {
         String randomLogFileName = UUID.randomUUID().toString() + ".log";
         String randomLoggerName = UUID.randomUUID().toString();
         String randomString = UUID.randomUUID().toString();
-        Logger logger2 = LogManager.getLogger(randomLoggerName, LoggerConfiguration.builder()
+        Logger logger2 = LogManager.getLogger(randomLoggerName, LogConfigUpdate.builder()
                 .fileName(randomLogFileName)
                 .build());
         Logger logger2Child = logger2.createChild();
@@ -147,7 +147,7 @@ class FileLoggerTest {
         String randomLoggerName = UUID.randomUUID().toString();
 
         logger = LogManager.getLogger(FileLoggerTest.class);
-        Logger logger2 = LogManager.getLogger(randomLoggerName, LoggerConfiguration.builder()
+        Logger logger2 = LogManager.getLogger(randomLoggerName, LogConfigUpdate.builder()
                 .fileName(randomLogFileName)
                 .build());
 
@@ -171,7 +171,7 @@ class FileLoggerTest {
         }
         LogManager.setRoot(tempRootDir.resolve(randomFolder2));
         logger.atInfo().log(randomString + "SomeOtherThing");
-        logger2 = LogManager.getLogger(randomLoggerName, LoggerConfiguration.builder()
+        logger2 = LogManager.getLogger(randomLoggerName, LogConfigUpdate.builder()
                 .fileName(randomLogFileName)
                 .build());
         logger2.atInfo().log(randomString + "SomeOtherThing");

--- a/src/test/java/com/aws/greengrass/logging/impl/LoggerTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/LoggerTest.java
@@ -49,12 +49,12 @@ class LoggerTest {
     @BeforeEach
     void beforeTesting() {
         System.setProperty("root", tempDir.toAbsolutePath().toString());
-        LogConfig.getInstance().setLevel(Level.TRACE);
+        LogConfig.getRootLogConfig().setLevel(Level.TRACE);
     }
 
     @Test
     void GIVEN_logger_for_name_WHEN_check_level_THEN_level_is_info_by_default() {
-        LogConfig.getInstance().setLevel(Level.INFO);
+        LogConfig.getRootLogConfig().setLevel(Level.INFO);
         Logger logger = LogManager.getLogger("test");
 
         assertEquals("test", logger.getName());
@@ -73,7 +73,7 @@ class LoggerTest {
     @Test
     void GIVEN_logger_WHEN_log_at_level_below_setting_THEN_message_is_not_logged() {
         // Setup logger with spy
-        LogConfig.getInstance().setLevel(Level.INFO);
+        LogConfig.getRootLogConfig().setLevel(Level.INFO);
         Slf4jLogAdapter logger = (Slf4jLogAdapter) LogManager.getLogger("test");
         org.slf4j.Logger loggerSpy = setupLoggerSpy(logger);
 

--- a/src/test/java/com/aws/greengrass/logging/impl/config/LogConfigTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/config/LogConfigTest.java
@@ -60,8 +60,7 @@ class LogConfigTest {
 
         assertEquals(LogStore.CONSOLE, config.getStore());
         assertEquals(Level.DEBUG, config.getLevel());
-        // This format is text because the default value in LoggerConfiguration builder is to use TEXT
-        assertEquals(LogFormat.TEXT, config.getFormat());
+        assertEquals(LogFormat.JSON, config.getFormat());
         assertTrue(config.getStoreName().endsWith(DEFAULT_STORE_NAME));
         assertEquals(DEFAULT_STORE_NAME, config.getFileName());
 

--- a/src/test/java/com/aws/greengrass/logging/impl/config/LogConfigTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/config/LogConfigTest.java
@@ -5,7 +5,7 @@
 
 package com.aws.greengrass.logging.impl.config;
 
-import com.aws.greengrass.logging.impl.config.model.LoggerConfiguration;
+import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
@@ -23,8 +23,8 @@ class LogConfigTest {
 
     @Test
     void GIVEN_provided_LoggerConfiguration_THEN_LogConfig_is_configured_the_same() {
-        LoggerConfiguration builder = LoggerConfiguration.builder().build();
-        LogConfig config = new LogConfig(builder);
+        LogConfigUpdate builder = LogConfigUpdate.builder().build();
+        LogConfig config = LogConfig.newLogConfigFromRootConfig(builder);
 
         assertEquals(LogStore.CONSOLE, config.getStore());
         assertEquals(Level.INFO, config.getLevel());
@@ -32,18 +32,18 @@ class LogConfigTest {
         assertTrue(config.getStoreName().endsWith(DEFAULT_STORE_NAME));
         assertEquals(DEFAULT_STORE_NAME, config.getFileName());
 
-        builder = LoggerConfiguration.builder().level(Level.TRACE).build();
-        config = new LogConfig(builder);
+        builder = LogConfigUpdate.builder().level(Level.TRACE).build();
+        config = LogConfig.newLogConfigFromRootConfig(builder);
 
         assertEquals(Level.TRACE, config.getLevel());
 
-        builder = LoggerConfiguration.builder().format(LogFormat.JSON).build();
-        config = new LogConfig(builder);
+        builder = LogConfigUpdate.builder().format(LogFormat.JSON).build();
+        config = LogConfig.newLogConfigFromRootConfig(builder);
 
         assertEquals(LogFormat.JSON, config.getFormat());
 
-        builder = LoggerConfiguration.builder().fileName("abc").build();
-        config = new LogConfig(builder);
+        builder = LogConfigUpdate.builder().fileName("abc").build();
+        config = LogConfig.newLogConfigFromRootConfig(builder);
 
         assertTrue(config.getStoreName().endsWith("abc"));
         assertEquals("abc", config.getFileName());
@@ -55,8 +55,8 @@ class LogConfigTest {
         root.setLevel(Level.DEBUG);
         root.setFormat(LogFormat.JSON);
 
-        LoggerConfiguration builder = LoggerConfiguration.builder().build();
-        LogConfig config = new LogConfig(builder);
+        LogConfigUpdate builder = LogConfigUpdate.builder().build();
+        LogConfig config = LogConfig.newLogConfigFromRootConfig(builder);
 
         assertEquals(LogStore.CONSOLE, config.getStore());
         assertEquals(Level.DEBUG, config.getLevel());
@@ -64,19 +64,19 @@ class LogConfigTest {
         assertTrue(config.getStoreName().endsWith(DEFAULT_STORE_NAME));
         assertEquals(DEFAULT_STORE_NAME, config.getFileName());
 
-        builder = LoggerConfiguration.builder().level(Level.TRACE).build();
-        config = new LogConfig(builder);
+        builder = LogConfigUpdate.builder().level(Level.TRACE).build();
+        config = LogConfig.newLogConfigFromRootConfig(builder);
 
         assertEquals(Level.TRACE, config.getLevel());
 
-        builder = LoggerConfiguration.builder().format(LogFormat.TEXT).build();
-        config = new LogConfig(builder);
+        builder = LogConfigUpdate.builder().format(LogFormat.TEXT).build();
+        config = LogConfig.newLogConfigFromRootConfig(builder);
 
         assertEquals(LogFormat.TEXT, config.getFormat());
 
         root.setStore(LogStore.FILE);
-        builder = LoggerConfiguration.builder().outputType(LogStore.CONSOLE).build();
-        config = new LogConfig(builder);
+        builder = LogConfigUpdate.builder().outputType(LogStore.CONSOLE).build();
+        config = LogConfig.newLogConfigFromRootConfig(builder);
 
         assertEquals(LogStore.CONSOLE, config.getStore());
     }

--- a/src/test/java/com/aws/greengrass/logging/impl/config/LogConfigTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/config/LogConfigTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class LogConfigTest {
     @AfterEach
     void cleanup() {
-        LogConfig.getInstance().reset();
+        LogConfig.getRootLogConfig().reset();
     }
 
 
@@ -51,7 +51,7 @@ class LogConfigTest {
 
     @Test
     void GIVEN_provided_LoggerConfiguration_and_global_THEN_LogConfig_is_configured_with_merged() {
-        LogConfig root = LogConfig.getInstance();
+        LogConfig root = LogConfig.getRootLogConfig();
         root.setLevel(Level.DEBUG);
         root.setFormat(LogFormat.JSON);
 


### PR DESCRIPTION
**Issue #, if available:**
https://issues.amazon.com/issues/AWSDocsSchedule-6356

**Description of changes:**
- Fix bug: config not applying to component log.
- Support RESET logging topics to revert to default.

**Why is this change necessary:**
- This allows customers to configure greengrass logging as desired

**How was this change tested:**
- Added unit tests
- Added UATs

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
