### PR TITLE
Upgrade logback dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.3.0-alpha1</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.0-alpha1</version>
+            <version>1.3.0-alpha4</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Upgrade `logback` dependency version.

**Why is this change necessary:**
Newer version includes critical bug fix. It's necessary to upgrade even though next stable version hasn't been released yet.

Logback release logs: http://logback.qos.ch/news.html

~`alpha5` version requires slf4j-api version 2.0.x, but we depend on 1.7.30, therefore upgrading to `alpha4`.~

We're affected by https://jira.qos.ch/browse/LOGBACK-1175 which is fixed in `alpha1`.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
