### PR TITLE
fix: add NopMDCAdapter to stop confusing error log

### DIFF
--- a/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.slf4j.impl;
+
+import org.slf4j.helpers.NOPMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
+
+/**
+ * This implementation is bound to {@link NOPMDCAdapter}.
+ */
+public class StaticMDCBinder {
+
+    /**
+     * The unique instance of this class.
+     */
+    public static final StaticMDCBinder SINGLETON = new StaticMDCBinder();
+
+    private StaticMDCBinder() {
+    }
+
+    /**
+     * Currently this method always returns an instance of
+     * {@link NOPMDCAdapter}.
+     */
+    public MDCAdapter getMDCA() {
+        return new NOPMDCAdapter();
+    }
+
+    public String getMDCAdapterClassStr() {
+        return NOPMDCAdapter.class.getName();
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Without a StaticMDCBinder we get
```
SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
SLF4J: Defaulting to no-operation MDCAdapter implementation.
SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
Successfully set up Nucleus as a system service
```

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
