### PR TITLE
chore: use latest dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
     <artifactId>logging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -25,13 +25,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.5.2</version>
+            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
+            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -43,30 +43,30 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.2.0</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.2.0</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.3</version>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.measure</groupId>
             <artifactId>jsr-275</artifactId>
-            <version>0.9.2</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <version>4.0.1</version>
+            <version>4.4.2</version>
         </dependency>
     </dependencies>
     <pluginRepositories>

--- a/src/test/java/com/aws/greengrass/logging/impl/StructuredLayoutTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/StructuredLayoutTest.java
@@ -83,13 +83,10 @@ public class StructuredLayoutTest {
     }
 
     @Test
-    public void GIVEN_throwable_that_fails_default_serializer_WHEN_use_custom_serializer_THEN_succeeds()
+    public void GIVEN_throwable_WHEN_use_custom_serializer_THEN_succeeds()
             throws JsonProcessingException {
         Throwable cause = assertThrows(JsonProcessingException.class,
                 () -> JSON_MAPPER.readValue("this will go wrong", Object.class));
-
-        // Default serializer should fail to serialize this throwable
-        assertThrows(JsonProcessingException.class, () -> JSON_MAPPER.writeValueAsString(cause));
 
         GreengrassLogMessage message = new GreengrassLogMessage();
         message.setMessage("testing");


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bumping all dependency versions including Jackson. Increasing version number to 2.1.1 so that older builds of Nucleus can still pull the older version of logging with the previous dependencies.

Changed test which asserted that Jackson couldn't serialize a Jackson exception because Jackson can do it now, but we still want to use our own serializer for throwables to avoid any possible situation like this in the future.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
