### PR TITLE
fix: do not create unnecessary metrics files on new root directory

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/LogManager.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/LogManager.java
@@ -89,6 +89,7 @@ public class LogManager {
     public static com.aws.greengrass.logging.api.Logger getTelemetryLogger(String name) {
         return telemetryLoggerMap.computeIfAbsent(name, n -> {
             Logger logger = telemetryConfig.getLogger(name);
+            telemetryConfig.telemetryLoggerNamesSet.add(name);
             return new Slf4jLogAdapter(logger, telemetryConfig);
         });
     }

--- a/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
+++ b/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
@@ -19,7 +19,9 @@ import org.slf4j.event.Level;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.aws.greengrass.telemetry.impl.MetricFactory.METRIC_LOGGER_PREFIX;
 
@@ -29,6 +31,7 @@ public class TelemetryConfig extends PersistenceConfig {
     public static final String CONFIG_PREFIX = "log";
     public static final String METRICS_SWITCH_KEY = "log.metricsEnabled";
     public static final String TELEMETRY_DIRECTORY = "telemetry";
+    public final Set<String> telemetryLoggerNamesSet = new HashSet<>();
     private static final Boolean DEFAULT_METRICS_SWITCH = true;
     private static final String DEFAULT_TELEMETRY_LOG_LEVEL = "TRACE";
     private static final TelemetryConfig INSTANCE = new TelemetryConfig();
@@ -117,7 +120,7 @@ public class TelemetryConfig extends PersistenceConfig {
         closeContext();
         //Reconfigure all the telemetry loggers to use the store at new path.
         for (Logger logger : context.getLoggerList()) {
-            if (!logger.getName().equals("ROOT")) {
+            if (!logger.getName().equals("ROOT") && telemetryLoggerNamesSet.contains(logger.getName())) {
                 editConfigForLogger(logger.getName());
             }
         }
@@ -185,7 +188,7 @@ public class TelemetryConfig extends PersistenceConfig {
             closeContext();
             // Reconfigure all the telemetry loggers to use the store at new path.
             for (Logger logger : context.getLoggerList()) {
-                if (!logger.getName().equals("ROOT")) {
+                if (!logger.getName().equals("ROOT") && telemetryLoggerNamesSet.contains(logger.getName())) {
                     editConfigForLogger(logger.getName());
                 }
             }

--- a/src/test/java/com/aws/greengrass/telemetry/impl/MetricFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/telemetry/impl/MetricFactoryTest.java
@@ -274,6 +274,27 @@ class MetricFactoryTest {
         assertTrue(new File(path2 + "/someFile.log").exists());
     }
 
+    @Test
+    void GIVEN_metric_factory_WHEN_new_telemetry_root_directory_THEN_does_not_create_unnecessary_metric_files() {
+        MetricFactory mf1 = new MetricFactory("com.example.component");
+        Metric m = Metric.builder().namespace("A").name("B").unit(TelemetryUnit.Percent).value(10)
+                .aggregation(TelemetryAggregation.Average).timestamp((long) 10).build();
+        mf1.putMetricData(m);
+
+        assertTrue(Files.exists(TelemetryConfig.getTelemetryDirectory().resolve("com.example.component.log")));
+        assertFalse(Files.exists(TelemetryConfig.getTelemetryDirectory().resolve("com.example.log")));
+        assertFalse(Files.exists(TelemetryConfig.getTelemetryDirectory().resolve("com.log")));
+
+        Path newTempRoot = tempRootDir.resolve("someNewRootDir");
+        TelemetryConfig.getInstance().setRoot(newTempRoot);
+        mf1.putMetricData(m);
+        newTempRoot = newTempRoot.resolve(TelemetryConfig.TELEMETRY_DIRECTORY);
+
+        assertTrue(Files.exists(newTempRoot.resolve("com.example.component.log")));
+        assertFalse(Files.exists(newTempRoot.resolve("com.example.log")));
+        assertFalse(Files.exists(newTempRoot.resolve("com.log")));
+    }
+
     private Logger setupLoggerSpy(MetricFactory mf) {
         Logger loggerSpy = spy(mf.getLogger());
         mf.setLogger(loggerSpy);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add a set of telemetry loggers and only `reconfigure` those loggers that are needed. 

**Why is this change necessary:**
Without this change, additional loggers like anything separated by  a `.` get `reconfigured` and new metrics are duplicated.

**How was this change tested:**
Added unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
