### PR TITLE
add prefix to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+        prefix: "chore(deps):"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-        prefix: "chore(deps):"
+        prefix: "chore(deps)"


### PR DESCRIPTION
Fix dependabot commit messages so they don't run afoul of the linter
