### PR TITLE
fix: cleanup old log files immediately

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
@@ -355,6 +355,7 @@ public class PersistenceConfig {
                 .toString());
         logFilePolicy.setMaxFileSize(new FileSize(fileSizeKB * FileSize.KB_COEFFICIENT));
         logFilePolicy.setMaxHistory(maxHistory);
+        logFilePolicy.setCleanHistoryOnStart(true);
         logFilePolicy.start();
 
         fileAppender.setRollingPolicy(logFilePolicy);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix a potential issue whereby logs may accumulate over the max store size by immediately cleaning any old logs.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
