### PR TITLE
chore(deps): bump logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.7</version>
+            <version>1.3.12</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.12</version>
+            <version>1.3.13</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/LogConfig.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
 import org.slf4j.event.Level;
+import org.slf4j.impl.StaticMDCBinder;
 
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -37,6 +38,8 @@ public class LogConfig extends PersistenceConfig {
     @SuppressFBWarnings("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR")
     protected LogConfig() {
         super(LOG_FILE_EXTENSION, LOGS_DIRECTORY);
+        // Must set an MDC adapter for 1.3.8+. https://github.com/qos-ch/logback/issues/709
+        context.setMDCAdapter(StaticMDCBinder.SINGLETON.getMDCA());
         reconfigure(context.getLogger(Logger.ROOT_LOGGER_NAME));
         startContext();
     }

--- a/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
+++ b/src/main/java/com/aws/greengrass/telemetry/impl/config/TelemetryConfig.java
@@ -17,6 +17,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
 import lombok.Setter;
 import org.slf4j.event.Level;
+import org.slf4j.impl.StaticMDCBinder;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,6 +48,8 @@ public class TelemetryConfig extends PersistenceConfig {
     @SuppressFBWarnings("MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR")
     private TelemetryConfig() {
         super(CONFIG_PREFIX);
+        // Must set an MDC adapter for 1.3.8+. https://github.com/qos-ch/logback/issues/709
+        context.setMDCAdapter(StaticMDCBinder.SINGLETON.getMDCA());
         boolean metricsEnabled = DEFAULT_METRICS_SWITCH;
         String enabledStr = System.getProperty(METRICS_SWITCH_KEY);
         if (enabledStr != null) {


### PR DESCRIPTION
Update logback to v1.3.13. 

Requires setting an MDC adapter in the logging context due to a change in logback 1.3.8.