### PR TITLE
fix: update logback to clean log files by last modified date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
     <artifactId>logging</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -12,6 +12,25 @@
             <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
+
+    <repositories>
+        <repository>
+            <id>greengrass-common</id>
+            <name>greengrass common</name>
+            <!-- CloudFront url fronting the device sdk,logging library and component common in S3-->
+            <url>https://d2jrmugq4soldf.cloudfront.net/snapshots</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,7 +89,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.14</version>
+            <version>1.3.14-GG-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.3.14-GG-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
@@ -12,6 +12,7 @@ import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.encoder.EncoderBase;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy;
+import ch.qos.logback.core.util.Duration;
 import ch.qos.logback.core.util.FileSize;
 import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -357,6 +358,10 @@ public class PersistenceConfig {
                 .toString());
         logFilePolicy.setMaxFileSize(new FileSize(fileSizeKB * FileSize.KB_COEFFICIENT));
         logFilePolicy.setMaxHistory(maxHistory);
+        // TODO - consider letting customers configure how often GG should check logs for rollover / cleanup
+        // Check every 2.0 second for now
+        logFilePolicy.setCheckIncrement(Duration.buildBySeconds(2.0));
+        logFilePolicy.setCleanLogsByLastModifiedDate(true);
         logFilePolicy.start();
 
         fileAppender.setRollingPolicy(logFilePolicy);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

1. Bump minor version to 2.3.0-SNAPSHOT
2. Use Snapshot of Logback 1.3.14 which contains the code changes and exclude logback parent 1.3.14-snapshot
3. Add Logback Parent 1.3.14 as an explicit dependency
4. Update Persistence config to enable new flag and cleanup check increment

**Why is this change necessary:**
We want Logback to clean up all old files instead of generating a list of expected file names that only goes backwards up to 14 days and deleting them if they exist.

**How was this change tested:**
- Changed clock to a time far into the past, created a log file with a correct name format.
- Moved clock to current time
- Started Greengrass
- Old log file was cleaned up

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
