### PR TITLE
fix: enable setCleanHistoryOnStart flag

### DIFF
--- a/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/PersistenceConfig.java
@@ -362,6 +362,7 @@ public class PersistenceConfig {
         // Check every 2.0 second for now
         logFilePolicy.setCheckIncrement(Duration.buildBySeconds(2.0));
         logFilePolicy.setCleanLogsByLastModifiedDate(true);
+        logFilePolicy.setCleanHistoryOnStart(true);
         logFilePolicy.start();
 
         fileAppender.setRollingPolicy(logFilePolicy);


### PR DESCRIPTION
**Issue #, if available:**
Logback wasn't cleaning files on start up

**Description of changes:**
Set log file policy setCleanHistoryOnStart to true

**Why is this change necessary:**
This will have Logback run the cleanup logic on startup instead of waiting for the next trigger

**How was this change tested:**
Tested locally and using Logback UATs

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
