### PR TITLE
feat: add raw/passthrough log format for EMF output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.aws.greengrass</groupId>
     <artifactId>logging</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/src/main/java/com/aws/greengrass/logging/impl/LogManager.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/LogManager.java
@@ -6,11 +6,14 @@
 package com.aws.greengrass.logging.impl;
 
 import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.logging.impl.config.LogFormat;
+import com.aws.greengrass.logging.impl.config.LogStore;
 import com.aws.greengrass.logging.impl.config.PersistenceConfig;
 import com.aws.greengrass.logging.impl.config.model.LogConfigUpdate;
 import com.aws.greengrass.telemetry.impl.config.TelemetryConfig;
 import lombok.Getter;
 import org.slf4j.Logger;
+import org.slf4j.event.Level;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -92,6 +95,26 @@ public class LogManager {
             telemetryConfig.telemetryLoggerNamesSet.add(name);
             return new Slf4jLogAdapter(logger, telemetryConfig);
         });
+    }
+
+
+    /**
+     * Creates a logger that writes raw messages (no envelope) to a dedicated rolling file.
+     * Intended for structured output like EMF where the consumer expects unmodified JSON per line.
+     *
+     * @param name      logger name, also used as the log file prefix
+     * @param outputDir directory for the log file
+     * @return a Logger that writes raw lines with no timestamp, level, or logger metadata
+     */
+    public static com.aws.greengrass.logging.api.Logger getRawLogger(String name, Path outputDir) {
+        LogConfigUpdate rawConfigUpdate = LogConfigUpdate.builder()
+                .format(LogFormat.RAW)
+                .outputDirectory(outputDir.toString())
+                .fileName(name)
+                .outputType(LogStore.FILE)
+                .level(Level.TRACE)
+                .build();
+        return getLogger(name, rawConfigUpdate);
     }
 
 

--- a/src/main/java/com/aws/greengrass/logging/impl/Slf4jLogAdapter.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/Slf4jLogAdapter.java
@@ -253,12 +253,16 @@ public class Slf4jLogAdapter implements Logger {
     }
 
     private String serialize(GreengrassLogMessage message) {
-        if (LogFormat.TEXT.equals(config.getFormat())) {
-            return message.getTextMessage();
-        } else if (LogFormat.JSON.equals(config.getFormat())) {
-            return message.getJSONMessage();
+        switch (config.getFormat()) {
+            case TEXT:
+                return message.getTextMessage();
+            case JSON:
+                return message.getJSONMessage();
+            case RAW:
+                return message.getMessage();
+            default:
+                return "ERROR Unknown LogFormat " + config.getFormat();
         }
-        return "ERROR Unknown LogFormat " + config.getFormat();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/logging/impl/config/LogFormat.java
+++ b/src/main/java/com/aws/greengrass/logging/impl/config/LogFormat.java
@@ -6,5 +6,5 @@
 package com.aws.greengrass.logging.impl.config;
 
 public enum LogFormat {
-    JSON, TEXT
+    JSON, TEXT, RAW
 }

--- a/src/test/java/com/aws/greengrass/logging/impl/RawLoggerTest.java
+++ b/src/test/java/com/aws/greengrass/logging/impl/RawLoggerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.logging.impl;
+
+import com.aws.greengrass.logging.api.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RawLoggerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void GIVEN_raw_logger_WHEN_log_message_THEN_only_raw_message_written() throws IOException {
+        String name = "test-raw-" + UUID.randomUUID();
+        Logger rawLogger = LogManager.getRawLogger(name, tempDir);
+
+        String emfJson = "{\"_aws\":{\"Timestamp\":1234567890},\"metric\":42}";
+        rawLogger.atInfo().log(emfJson);
+
+        // Verify multiple lines are written raw
+        rawLogger.atInfo().log("second-line");
+
+        Path logFile = tempDir.resolve(name + ".log");
+        assertTrue(Files.exists(logFile), "Raw log file should be created");
+
+        List<String> lines = Files.readAllLines(logFile);
+        // Each line should be the raw message — no timestamp, level, logger name, or thread
+        assertEquals(emfJson, lines.get(0));
+        assertEquals("second-line", lines.get(1));
+        assertFalse(lines.get(0).contains("[INFO]"), "Should not contain log level envelope");
+        assertFalse(lines.get(0).contains("raw."), "Should not contain logger name");
+    }
+
+    @Test
+    void GIVEN_raw_logger_WHEN_log_with_placeholders_THEN_placeholders_resolved() throws IOException {
+        String name = "fmt-test-" + UUID.randomUUID();
+        Logger rawLogger = LogManager.getRawLogger(name, tempDir);
+
+        rawLogger.atInfo().log("value is {}", 42);
+
+        Path logFile = tempDir.resolve(name + ".log");
+        List<String> lines = Files.readAllLines(logFile);
+        assertEquals("value is 42", lines.get(0),
+                "Placeholders should be resolved — getMessage() returns the formatted string");
+    }
+
+    @Test
+    void GIVEN_raw_logger_WHEN_log_message_THEN_does_not_propagate_to_root() throws IOException {
+        String name = "no-propagate-" + UUID.randomUUID();
+        Logger rawLogger = LogManager.getRawLogger(name, tempDir);
+
+        // Get root logger and log something to establish baseline
+        Logger rootLogger = LogManager.getLogger("root-test");
+        String rootMarker = "ROOT-" + UUID.randomUUID();
+        rootLogger.atInfo().log(rootMarker);
+
+        // Log through raw logger
+        String rawMarker = "RAW-" + UUID.randomUUID();
+        rawLogger.atInfo().log(rawMarker);
+
+        // Raw log file should contain the raw message
+        Path rawLogFile = tempDir.resolve(name + ".log");
+        assertTrue(Files.exists(rawLogFile));
+        List<String> rawLines = Files.readAllLines(rawLogFile);
+        assertTrue(rawLines.stream().anyMatch(l -> l.equals(rawMarker)),
+                "Raw log file should contain the raw message");
+
+        // Root log file should NOT contain the raw message — serialize() applies RAW format per-logger
+        String rootStoreName = LogManager.getRootLogConfiguration().getStoreName();
+        if (rootStoreName != null && Files.exists(Paths.get(rootStoreName))) {
+            List<String> rootLines = Files.readAllLines(Paths.get(rootStoreName));
+            assertFalse(rootLines.stream().anyMatch(l -> l.contains(rawMarker)),
+                    "Root log should not contain raw logger messages");
+        }
+    }
+
+}


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Add raw/passthrough log format support to enable CloudWatch Logs EMF (Embedded Metric Format) output from Greengrass components.

The GG logging library wraps every message in a structured envelope — either TEXT format (`2026-04-09T14:55:00Z [INFO] (main) Logger: <message>`) or JSON format (`{"thread":"main","level":"INFO","message":"<message>",...}`). CloudWatch Logs EMF parser requires each line to be a standalone JSON object starting with `{"_aws":{...}}`, so the envelope breaks EMF parsing.

Changes (4 files, ~130 lines):
1. `LogFormat.RAW` — new enum value
2. `Slf4jLogAdapter.serialize()` — handles `RAW` format by returning `message.getMessage()` (raw string, no envelope)
3. `LogManager.getRawLogger(name, outputDir)` — factory method that creates a dedicated logger via the existing `getLogger(name, LogConfigUpdate)` pattern with `format=RAW`, `outputType=FILE`, and `level=TRACE`
4. `RawLoggerTest` — 3 tests: raw output format, placeholder resolution, non-propagation to root logger

**Why is this change necessary:**

The `aws-greengrass-telemetry-nucleus-emitter` component needs to write EMF JSON to files for CloudWatch Logs ingestion. Without a raw format, the component must manage its own file writing and rotation. With `getRawLogger`, it delegates file lifecycle to the existing GG logging infrastructure while writing unmodified EMF JSON lines.

**How was this change tested:**

- 3 new unit tests covering raw output (no envelope), placeholder resolution (`{}` args are resolved before `getMessage()`), and non-propagation to root logger
- Non-propagation verified: raw messages do not appear in the root log file because `Slf4jLogAdapter.serialize()` applies the RAW format per-logger before the message reaches Logback's appender hierarchy
- Local build + test with JDK 11 (source 1.8 target 1.8) — 0 new failures
- 3 pre-existing `StructuredLayoutTest` failures on `main` are unchanged

**Any additional information or context required to review the change:**

- Reuses the existing `getLogger(name, LogConfigUpdate)` pattern — no new Logback appender setup code
- `BasicEncoder` already writes raw formatted messages; the key change is in `Slf4jLogAdapter.serialize()` which now returns `message.getMessage()` for `RAW` format instead of wrapping in TEXT/JSON envelope
- No explicit setAdditive(false) needed — getRawLogger delegates to getLogger(name, LogConfigUpdate) which creates a new LogConfig with its own LoggerContext (LogConfig.java:24). The raw logger is the ROOT of this isolated context with no parent, so messages cannot propagate. This is the same isolation used by any logger created with custom LogConfigUpdate (validated by FileLoggerTest.GIVEN_new_logger_with_config).
- Consumer PR: https://github.com/aws-greengrass/aws-greengrass-telemetry-nucleus-emitter/pull/21

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
